### PR TITLE
Fixed sphere-to-sphere collisions

### DIFF
--- a/source/objects/components/collisions/Collider.cpp
+++ b/source/objects/components/collisions/Collider.cpp
@@ -177,7 +177,7 @@ bool Collider::handleSphereToSphereCollision(const std::shared_ptr<Collider>& ot
 
   if (const float dist = length(delta); dist < combinedRadius)
   {
-    const auto minimumTranslationVector = -(normalize(delta) * (combinedRadius - dist));
+    const auto minimumTranslationVector = dist != 0.0f ? -(normalize(delta) * (combinedRadius - dist)) : glm::vec3(0, combinedRadius / 2.0f, 0);
 
     if (mtv != nullptr)
     {

--- a/source/objects/components/collisions/Collider.cpp
+++ b/source/objects/components/collisions/Collider.cpp
@@ -175,27 +175,29 @@ bool Collider::handleSphereToSphereCollision(const std::shared_ptr<Collider>& ot
   const auto combinedRadius = sphereA->getRadius() + sphereB->getRadius();
   const auto delta = otherCollider->getPosition() - getPosition();
 
-  if (const float dist = length(delta); dist < combinedRadius)
+  const float dist = length(delta);
+
+  if (dist >= combinedRadius)
   {
-    const auto minimumTranslationVector = dist != 0.0f ? -(normalize(delta) * (combinedRadius - dist)) : glm::vec3(0, combinedRadius / 2.0f, 0);
-
-    if (mtv != nullptr)
-    {
-      *mtv = minimumTranslationVector;
-    }
-
-    if (collisionPoint != nullptr)
-    {
-      const auto direction = -glm::normalize(minimumTranslationVector);
-      const auto pointOfCollision = getPosition() + direction * std::dynamic_pointer_cast<SphereCollider>(otherCollider)->getRadius();
-
-      *collisionPoint = pointOfCollision;
-    }
-
-    return true;
+    return false;
   }
 
-  return false;
+  const auto minimumTranslationVector = dist != 0.0f ? -(normalize(delta) * (combinedRadius - dist)) : glm::vec3(0, combinedRadius / 2.0f, 0);
+
+  if (mtv != nullptr)
+  {
+    *mtv = minimumTranslationVector;
+  }
+
+  if (collisionPoint != nullptr)
+  {
+    const auto direction = -glm::normalize(minimumTranslationVector);
+    const auto pointOfCollision = getPosition() + direction * std::dynamic_pointer_cast<SphereCollider>(otherCollider)->getRadius();
+
+    *collisionPoint = pointOfCollision;
+  }
+
+  return true;
 }
 
 glm::vec3 Collider::getSupport(const std::shared_ptr<Collider>& other, const glm::vec3& direction)

--- a/source/objects/components/collisions/Collider.cpp
+++ b/source/objects/components/collisions/Collider.cpp
@@ -192,7 +192,7 @@ bool Collider::handleSphereToSphereCollision(const std::shared_ptr<Collider>& ot
   if (collisionPoint != nullptr)
   {
     const auto direction = -glm::normalize(minimumTranslationVector);
-    const auto pointOfCollision = getPosition() + direction * std::dynamic_pointer_cast<SphereCollider>(otherCollider)->getRadius();
+    const auto pointOfCollision = getPosition() + direction * sphereB->getRadius();
 
     *collisionPoint = pointOfCollision;
   }


### PR DESCRIPTION
This pull request refines the sphere-to-sphere collision handling logic in the `Collider` component. The main improvement is a clearer and more robust collision check, especially for the edge case where the spheres are perfectly overlapping.

**Collision detection improvements:**

* Updated the collision condition in `Collider::handleSphereToSphereCollision` to return `false` immediately if the spheres are not intersecting, simplifying the logic and improving readability.
* Enhanced the calculation of the minimum translation vector (MTV) to handle the case where the distance between sphere centers is zero (perfect overlap), assigning a default MTV direction in this scenario.
* Removed unreachable code at the end of the function, as all code paths now return explicitly.