### PR TITLE
Separate GUI update flow

### DIFF
--- a/source/ECS3D.cpp
+++ b/source/ECS3D.cpp
@@ -78,6 +78,8 @@ bool ECS3D::isActive() const
 
 void ECS3D::update()
 {
+	updateGui();
+
 	fixedUpdate();
 
 	variableUpdate();
@@ -106,6 +108,11 @@ std::shared_ptr<AssetManager> ECS3D::getAssetManager() const
 std::shared_ptr<SaveManager> ECS3D::getSaveManager() const
 {
 	return m_saveManager;
+}
+
+void ECS3D::updateGui() const
+{
+	m_assetManager->displayGui();
 }
 
 void ECS3D::fixedUpdate()
@@ -142,8 +149,6 @@ void ECS3D::variableUpdate()
 	displayMenuBar();
 
 	try {
-		m_assetManager->displayGui();
-
 		m_sceneManager->variableUpdate();
 	}
 	catch(const std::exception& e)

--- a/source/ECS3D.cpp
+++ b/source/ECS3D.cpp
@@ -110,11 +110,13 @@ std::shared_ptr<SaveManager> ECS3D::getSaveManager() const
 	return m_saveManager;
 }
 
-void ECS3D::updateGui() const
+void ECS3D::updateGui()
 {
 	m_assetManager->displayGui();
 
 	m_sceneManager->updateGui();
+
+	displayMessageLog();
 }
 
 void ECS3D::fixedUpdate()
@@ -157,8 +159,6 @@ void ECS3D::variableUpdate()
 	{
 		logMessage("Error", e.what());
 	}
-
-	displayMessageLog();
 
 	m_renderer->render();
 }

--- a/source/ECS3D.cpp
+++ b/source/ECS3D.cpp
@@ -114,16 +114,20 @@ std::shared_ptr<SaveManager> ECS3D::getSaveManager() const
 
 void ECS3D::updateGui()
 {
+	displayMenuBar();
+
 	if (!m_shouldDisplayGui)
 	{
 		return;
 	}
 
+	updateDockSpace();
+
+	displayMessageLog();
+
 	m_assetManager->displayGui();
 
 	m_sceneManager->updateGui();
-
-	displayMessageLog();
 }
 
 void ECS3D::fixedUpdate()
@@ -155,10 +159,6 @@ void ECS3D::fixedUpdate()
 
 void ECS3D::variableUpdate()
 {
-	updateDockSpace();
-
-	displayMenuBar();
-
 	try {
 		m_sceneManager->variableUpdate();
 	}

--- a/source/ECS3D.cpp
+++ b/source/ECS3D.cpp
@@ -294,7 +294,7 @@ void ECS3D::setupKeybinds()
 			return;
 		}
 
-		if (keyIsPressed(GLFW_KEY_F10))
+		if (e.key == GLFW_KEY_F10)
 		{
 			m_shouldDisplayGui = !m_shouldDisplayGui;
 		}

--- a/source/ECS3D.cpp
+++ b/source/ECS3D.cpp
@@ -113,6 +113,8 @@ std::shared_ptr<SaveManager> ECS3D::getSaveManager() const
 void ECS3D::updateGui() const
 {
 	m_assetManager->displayGui();
+
+	m_sceneManager->updateGui();
 }
 
 void ECS3D::fixedUpdate()

--- a/source/ECS3D.cpp
+++ b/source/ECS3D.cpp
@@ -27,6 +27,8 @@ ECS3D::ECS3D()
 
 	m_scriptManager = std::make_shared<ScriptManager>(this);
 
+	setupKeybinds();
+
 	m_assetManager->loadAsset<ModelAsset>("assets/models/cube_1x1x1.glb");
 	m_assetManager->loadAsset<ModelAsset>("assets/models/sphere.glb");
 	m_assetManager->loadAsset<ModelAsset>("assets/models/sphere_2.glb");
@@ -112,6 +114,11 @@ std::shared_ptr<SaveManager> ECS3D::getSaveManager() const
 
 void ECS3D::updateGui()
 {
+	if (!m_shouldDisplayGui)
+	{
+		return;
+	}
+
 	m_assetManager->displayGui();
 
 	m_sceneManager->updateGui();
@@ -277,6 +284,21 @@ void ECS3D::updateDockSpace() const
 	gui->dockBottom("Project Errors");
 	gui->dockBottom("Smoke");
 	gui->dockBottom("Elliptical Dots");
+}
+
+void ECS3D::setupKeybinds()
+{
+	m_keyCallbackEventListener = m_renderer->getWindow()->on<vke::KeyCallbackEvent>([this](const vke::KeyCallbackEvent& e) {
+		if (e.action != GLFW_PRESS)
+		{
+			return;
+		}
+
+		if (keyIsPressed(GLFW_KEY_F10))
+		{
+			m_shouldDisplayGui = !m_shouldDisplayGui;
+		}
+	});
 }
 
 void ECS3D::setupImGuiStyle()

--- a/source/ECS3D.h
+++ b/source/ECS3D.h
@@ -68,6 +68,8 @@ private:
 
   std::shared_ptr<ScriptManager> m_scriptManager;
 
+  void updateGui() const;
+
   void fixedUpdate();
 
   void variableUpdate();

--- a/source/ECS3D.h
+++ b/source/ECS3D.h
@@ -68,7 +68,7 @@ private:
 
   std::shared_ptr<ScriptManager> m_scriptManager;
 
-  void updateGui() const;
+  void updateGui();
 
   void fixedUpdate();
 

--- a/source/ECS3D.h
+++ b/source/ECS3D.h
@@ -3,6 +3,7 @@
 
 #include <uuid.h>
 #include <VulkanEngine/VulkanEngine.h>
+#include <VulkanEngine/components/window/Window.h>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -68,6 +69,10 @@ private:
 
   std::shared_ptr<ScriptManager> m_scriptManager;
 
+  bool m_shouldDisplayGui = true;
+
+  vke::EventListener<vke::KeyCallbackEvent> m_keyCallbackEventListener;
+
   void updateGui();
 
   void fixedUpdate();
@@ -81,6 +86,8 @@ private:
   void displayMenuBar() const;
 
   void updateDockSpace() const;
+
+  void setupKeybinds();
 
   static void setupImGuiStyle();
 };

--- a/source/objects/ObjectManager.cpp
+++ b/source/objects/ObjectManager.cpp
@@ -10,6 +10,13 @@ ObjectManager::ObjectManager(ECS3D* ecs)
     m_objectGUIManager(std::make_shared<ObjectGUIManager>(this))
 {}
 
+void ObjectManager::updateGui() const
+{
+  m_objectGUIManager->update();
+
+  m_objectGUIManager->displaySelectedObjectGui();
+}
+
 void ObjectManager::fixedUpdate(const float dt) const
 {
   for (const auto& object : m_allObjects)
@@ -22,11 +29,7 @@ void ObjectManager::fixedUpdate(const float dt) const
 
 void ObjectManager::variableUpdate()
 {
-  m_objectGUIManager->update();
-
   deleteObjectsMarkedForDeletion();
-
-  m_objectGUIManager->displaySelectedObjectGui();
 
   for (const auto& object : m_allObjects)
   {

--- a/source/objects/ObjectManager.h
+++ b/source/objects/ObjectManager.h
@@ -15,6 +15,8 @@ class ObjectManager {
 public:
   explicit ObjectManager(ECS3D* ecs);
 
+  void updateGui() const;
+
   void fixedUpdate(float dt) const;
 
   void variableUpdate();

--- a/source/scenes/SceneManager.cpp
+++ b/source/scenes/SceneManager.cpp
@@ -1,5 +1,6 @@
 #include "SceneManager.h"
 #include "../assets/SceneAsset.h"
+#include "../objects/ObjectManager.h"
 #include <imgui.h>
 #include <stdexcept>
 
@@ -18,6 +19,11 @@ void SceneManager::loadScene(const std::shared_ptr<SceneAsset>& scene)
 void SceneManager::updateGui()
 {
   displaySceneStatusGui();
+
+  if (m_currentScene)
+  {
+    m_currentScene->getObjectManager()->updateGui();
+  }
 }
 
 void SceneManager::fixedUpdate(const float dt) const

--- a/source/scenes/SceneManager.cpp
+++ b/source/scenes/SceneManager.cpp
@@ -15,6 +15,11 @@ void SceneManager::loadScene(const std::shared_ptr<SceneAsset>& scene)
   m_currentScene = scene;
 }
 
+void SceneManager::updateGui()
+{
+  displaySceneStatusGui();
+}
+
 void SceneManager::fixedUpdate(const float dt) const
 {
   if (!m_currentScene || m_sceneStatus != SceneStatus::running)
@@ -27,8 +32,6 @@ void SceneManager::fixedUpdate(const float dt) const
 
 void SceneManager::variableUpdate()
 {
-  displaySceneStatusGui();
-
   if (m_currentScene)
   {
     m_currentScene->variableUpdate();

--- a/source/scenes/SceneManager.h
+++ b/source/scenes/SceneManager.h
@@ -15,6 +15,8 @@ class SceneManager {
 public:
   void loadScene(const std::shared_ptr<SceneAsset>& scene);
 
+  void updateGui();
+
   void fixedUpdate(float dt) const;
 
   void variableUpdate();


### PR DESCRIPTION
This pull request refactors and centralizes the GUI update logic across the ECS3D engine, improving maintainability and making GUI visibility toggleable at runtime. The most important changes are:

**Centralization and Control of GUI Updates:**

* Introduced a new `updateGui()` method in `ECS3D`, which now handles all GUI updates, including the menu bar, dock space, message log, asset manager, and scene manager GUIs, and is called at the start of the main update loop (`ECS3D::update()`). (`[[1]](diffhunk://#diff-062f10bc021d0435a7cf0b3bddd24f4f2f07ffb5262e27485ecd37afa146019aR83-R84)`, `[[2]](diffhunk://#diff-062f10bc021d0435a7cf0b3bddd24f4f2f07ffb5262e27485ecd37afa146019aR115-R132)`)
* Added a `m_shouldDisplayGui` flag and a `setupKeybinds()` method to `ECS3D`, allowing GUI display to be toggled at runtime via the F10 key. (`[[1]](diffhunk://#diff-062f10bc021d0435a7cf0b3bddd24f4f2f07ffb5262e27485ecd37afa146019aR30-R31)`, `[[2]](diffhunk://#diff-062f10bc021d0435a7cf0b3bddd24f4f2f07ffb5262e27485ecd37afa146019aR289-R303)`, `[[3]](diffhunk://#diff-c6eb2679ab4ac9d40633391dbf625a416f86412e21f8c1bf733723b37b64ac06R72-R77)`, `[[4]](diffhunk://#diff-c6eb2679ab4ac9d40633391dbf625a416f86412e21f8c1bf733723b37b64ac06R90-R91)`)

**Refactoring of Scene and Object GUI Updates:**

* Moved GUI update logic in `SceneManager` and `ObjectManager` into new `updateGui()` methods, which are now called from the centralized `ECS3D::updateGui()` instead of being scattered in variable update methods. (`[[1]](diffhunk://#diff-7ea79e821e9bcee55c2f51d1895cdefad7fe9bc3247b7ba1a5f94c32fee76dedR19-R28)`, `[[2]](diffhunk://#diff-7ea79e821e9bcee55c2f51d1895cdefad7fe9bc3247b7ba1a5f94c32fee76dedL30-L31)`, `[[3]](diffhunk://#diff-7ea79e821e9bcee55c2f51d1895cdefad7fe9bc3247b7ba1a5f94c32fee76dedR19-R28)`, `[[4]](diffhunk://#diff-ec2c24fb409ea45f302c0c0c3278d16d7a2621da9adafccbd6d4491962a80312R18-R19)`, `[[5]](diffhunk://#diff-f53620d2599722b0107e876c4867ef1f72a39d5d18c0f32d58eb1eb7316e594bR13-R19)`, `[[6]](diffhunk://#diff-f53620d2599722b0107e876c4867ef1f72a39d5d18c0f32d58eb1eb7316e594bL25-L30)`, `[[7]](diffhunk://#diff-6c570d63b10a0d2856905dc0cc1e410d8f121621307df0bdf4b0de8170f87bbdR18-R19)`)

**Code Cleanup and Dependency Updates:**

* Removed redundant GUI update calls from `variableUpdate()` methods in both `ECS3D` and `SceneManager`, and updated includes to reflect new dependencies. (`[[1]](diffhunk://#diff-062f10bc021d0435a7cf0b3bddd24f4f2f07ffb5262e27485ecd37afa146019aL140-L155)`, `[[2]](diffhunk://#diff-7ea79e821e9bcee55c2f51d1895cdefad7fe9bc3247b7ba1a5f94c32fee76dedL30-L31)`, `[[3]](diffhunk://#diff-c6eb2679ab4ac9d40633391dbf625a416f86412e21f8c1bf733723b37b64ac06R6)`, `[[4]](diffhunk://#diff-7ea79e821e9bcee55c2f51d1895cdefad7fe9bc3247b7ba1a5f94c32fee76dedR3)`)

These changes make GUI updates more predictable and easier to manage, and allow users to toggle the GUI on and off during runtime.