### PR TITLE
Support new asset creation

### DIFF
--- a/source/ECS3D.cpp
+++ b/source/ECS3D.cpp
@@ -257,6 +257,8 @@ void ECS3D::displayMenuBar() const
 			ImGui::EndMenu();
 		}
 
+		m_assetManager->displayMenuWidget();
+
 		ImGui::EndMainMenuBar();
 	}
 }

--- a/source/assets/AssetManager.cpp
+++ b/source/assets/AssetManager.cpp
@@ -157,7 +157,8 @@ void AssetManager::displayMenuWidget()
   displayCreateAssetPopup(pending, errorMessage);
 }
 
-void AssetManager::displayCreateAssetPopup(PendingAsset& pending, std::string& errorMessage)
+void AssetManager::displayCreateAssetPopup(PendingAsset& pending,
+                                           std::string& errorMessage)
 {
   const std::string title = " Create " + pending.toString() + "###CreateAssetModal";
 
@@ -218,7 +219,8 @@ void AssetManager::displayPopupSourcePath(const PendingAsset& pending)
   ImGui::Spacing();
 }
 
-void AssetManager::displayPopupNameInput(PendingAsset& pending, std::string& errorMessage)
+void AssetManager::displayPopupNameInput(PendingAsset& pending,
+                                         std::string& errorMessage)
 {
   ImGui::TextColored(kColorSubtle, "Asset Name");
 
@@ -246,7 +248,8 @@ void AssetManager::displayPopupNameInput(PendingAsset& pending, std::string& err
   }
 }
 
-void AssetManager::displayPopupActionButtons(PendingAsset& pending, std::string& errorMessage)
+void AssetManager::displayPopupActionButtons(PendingAsset& pending,
+                                             std::string& errorMessage)
 {
   const bool canCreate = pending.isValid() && nameIsValid(pending.name) &&
                          (!pending.requiresFilePicker() || !pending.path.empty());
@@ -311,7 +314,8 @@ void AssetManager::commitAssetCreation(const PendingAsset& pending)
   m_shouldComputeFilteredAssets = true;
 }
 
-void AssetManager::commitModelAsset(const std::string& name, const std::string& srcPath)
+void AssetManager::commitModelAsset(const std::string& name,
+                                    const std::string& srcPath)
 {
   const std::filesystem::path dstDir = "assets/models/";
   std::filesystem::create_directories(dstDir);
@@ -330,7 +334,8 @@ void AssetManager::commitModelAsset(const std::string& name, const std::string& 
   m_loadedPaths.emplace(finalPath, uuid);
 }
 
-void AssetManager::commitTextureAsset(const std::string& name, const std::string& srcPath)
+void AssetManager::commitTextureAsset(const std::string& name,
+                                      const std::string& srcPath)
 {
   const std::filesystem::path dstDir = "assets/textures/";
   std::filesystem::create_directories(dstDir);

--- a/source/assets/AssetManager.cpp
+++ b/source/assets/AssetManager.cpp
@@ -546,7 +546,7 @@ void AssetManager::displayAssetsFilterGui()
     ImGui::SameLine();
     if (ImGui::BeginCombo("##SortCombo", sortTypeToString.at(m_sortType).c_str()))
     {
-      for (const auto type : { SortType::nameAscending, SortType::nameDescending })
+      for (const auto type : { SortType::NameAscending, SortType::NameDescending })
       {
         if (ImGui::Selectable(sortTypeToString.at(type).c_str(), m_sortType == type))
         {
@@ -598,8 +598,9 @@ void AssetManager::computeFilteredAssets()
   }
 
   std::ranges::sort(m_filteredAssets, [this](const auto& a, const auto& b) {
-    return std::ranges::lexicographical_compare( a->getName(), b->getName(), [this](char x, char y) {
-      return m_sortType == SortType::nameAscending
+    return std::ranges::lexicographical_compare(a->getName(), b->getName(),
+                                                [this](const char x, const char y) {
+      return m_sortType == SortType::NameAscending
         ? std::tolower(x) < std::tolower(y)
         : std::tolower(x) > std::tolower(y);
     });

--- a/source/assets/AssetManager.cpp
+++ b/source/assets/AssetManager.cpp
@@ -6,6 +6,7 @@
 #include "TextureAsset.h"
 #include "../objects/Object.h"
 #include "../objects/ObjectManager.h"
+#include "../scenes/SceneManager.h"
 #include <imgui.h>
 #include <nfd.h>
 #include <nlohmann/json.hpp>
@@ -354,19 +355,11 @@ void AssetManager::commitTextureAsset(const std::string& name,
   m_loadedPaths.emplace(finalPath, uuid);
 }
 
-void AssetManager::commitSceneAsset(const std::string& name)
+void AssetManager::commitSceneAsset(std::string name)
 {
-  std::filesystem::create_directories("assets/scenes/");
-  const std::filesystem::path path = "assets/scenes/" + name + ".json";
+  const auto scene = createSceneAsset(std::move(name));
 
-  const nlohmann::json data = {
-    { "uuid", uuids::to_string(m_ecs->createUUID()) },
-    { "name", name },
-    { "objects", nlohmann::json::array() }
-  };
-
-  std::ofstream(path) << data.dump(2);
-  createSceneAsset(name);
+  m_ecs->getSceneManager()->loadScene(scene);
 }
 
 void AssetManager::commitScriptAsset(const std::string& name)

--- a/source/assets/AssetManager.cpp
+++ b/source/assets/AssetManager.cpp
@@ -43,7 +43,9 @@ void labeledSeparator(const char* label)
 std::optional<std::string> openFileDialog(const std::vector<nfdu8filteritem_t>& filters)
 {
   if (NFD_Init() != NFD_OKAY)
+  {
     throw std::runtime_error("NFD_Init failed");
+  }
 
   nfdu8char_t* outPath = nullptr;
 
@@ -194,7 +196,10 @@ void AssetManager::displayCreateAssetPopup(PendingAsset& pending, std::string& e
 
 void AssetManager::displayPopupSourcePath(const PendingAsset& pending)
 {
-  if (!pending.requiresFilePicker()) return;
+  if (!pending.requiresFilePicker())
+  {
+    return;
+  }
 
   ImGui::TextColored(kColorSubtle, "Source");
 
@@ -206,10 +211,7 @@ void AssetManager::displayPopupSourcePath(const PendingAsset& pending)
   ImGui::BeginChild("##sourcepath", ImVec2(-1, 28), false);
   ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 4.0f);
 
-  if (pending.path.empty())
-    ImGui::TextColored(kColorWarning, "%s", display.c_str());
-  else
-    ImGui::TextColored(kColorSuccess, "%s", display.c_str());
+  ImGui::TextColored(pending.path.empty() ? kColorWarning : kColorSuccess, "%s", display.c_str());
 
   ImGui::EndChild();
   ImGui::PopStyleColor();
@@ -227,7 +229,9 @@ void AssetManager::displayPopupNameInput(PendingAsset& pending, std::string& err
   const bool nameInvalid = !nameIsValid(pending.name);
 
   if (nameInvalid)
+  {
     ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.35f, 0.10f, 0.10f, 1.0f));
+  }
 
   ImGui::SetNextItemWidth(-1);
   if (ImGui::InputText("##assetname", nameBuf, sizeof(nameBuf)))
@@ -237,7 +241,9 @@ void AssetManager::displayPopupNameInput(PendingAsset& pending, std::string& err
   }
 
   if (nameInvalid)
+  {
     ImGui::PopStyleColor();
+  }
 }
 
 void AssetManager::displayPopupActionButtons(PendingAsset& pending, std::string& errorMessage)
@@ -246,7 +252,9 @@ void AssetManager::displayPopupActionButtons(PendingAsset& pending, std::string&
                          (!pending.requiresFilePicker() || !pending.path.empty());
 
   if (!canCreate)
+  {
     ImGui::BeginDisabled();
+  }
 
   pushButtonStyle(kColorAccent);
   if (ImGui::Button("Create", ImVec2(180, 0)))
@@ -264,7 +272,9 @@ void AssetManager::displayPopupActionButtons(PendingAsset& pending, std::string&
   popButtonStyle();
 
   if (!canCreate)
+  {
     ImGui::EndDisabled();
+  }
 
   ImGui::SameLine();
 

--- a/source/assets/AssetManager.cpp
+++ b/source/assets/AssetManager.cpp
@@ -362,7 +362,7 @@ void AssetManager::commitSceneAsset(std::string name)
   m_ecs->getSceneManager()->loadScene(scene);
 }
 
-void AssetManager::commitScriptAsset(const std::string& name)
+void AssetManager::commitScriptAsset(std::string name)
 {
   std::filesystem::create_directories("scripts/userScripts/");
   const std::filesystem::path path = "scripts/userScripts/" + name + ".cs";
@@ -380,7 +380,7 @@ void AssetManager::commitScriptAsset(const std::string& name)
     "    public override void stop() {}\n"
     "}\n";
 
-  loadScriptAsset(path.string(), name);
+  loadScriptAsset(path.string(), std::move(name));
 }
 
 void AssetManager::displayGui()

--- a/source/assets/AssetManager.cpp
+++ b/source/assets/AssetManager.cpp
@@ -15,68 +15,70 @@
 #include <fstream>
 #include <ranges>
 
-constexpr ImVec4 kColorSubtle   { 0.55f, 0.55f, 0.55f, 1.00f };
-constexpr ImVec4 kColorAccent   { 0.40f, 0.72f, 1.00f, 1.00f };
-constexpr ImVec4 kColorWarning  { 1.00f, 0.75f, 0.20f, 1.00f };
-constexpr ImVec4 kColorDanger   { 0.95f, 0.35f, 0.35f, 1.00f };
-constexpr ImVec4 kColorSuccess  { 0.35f, 0.85f, 0.55f, 1.00f };
+namespace {
+  constexpr ImVec4 kColorSubtle   { 0.55f, 0.55f, 0.55f, 1.00f };
+  constexpr ImVec4 kColorAccent   { 0.40f, 0.72f, 1.00f, 1.00f };
+  constexpr ImVec4 kColorWarning  { 1.00f, 0.75f, 0.20f, 1.00f };
+  constexpr ImVec4 kColorDanger   { 0.95f, 0.35f, 0.35f, 1.00f };
+  constexpr ImVec4 kColorSuccess  { 0.35f, 0.85f, 0.55f, 1.00f };
 
-void pushButtonStyle(const ImVec4 color)
-{
-  ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(color.x * 0.7f, color.y * 0.7f, color.z * 0.7f, 0.45f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(color.x * 0.9f, color.y * 0.9f, color.z * 0.9f, 0.65f));
-  ImGui::PushStyleColor(ImGuiCol_ButtonActive, color);
-}
-
-void popButtonStyle()
-{
-  ImGui::PopStyleColor(3);
-}
-
-void labeledSeparator(const char* label)
-{
-  ImGui::Spacing();
-  ImGui::TextColored(kColorSubtle, "%s", label);
-  ImGui::Separator();
-  ImGui::Spacing();
-}
-
-std::optional<std::string> openFileDialog(const std::vector<nfdu8filteritem_t>& filters)
-{
-  if (NFD_Init() != NFD_OKAY)
+  void pushButtonStyle(const ImVec4 color)
   {
-    throw std::runtime_error("NFD_Init failed");
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(color.x * 0.7f, color.y * 0.7f, color.z * 0.7f, 0.45f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(color.x * 0.9f, color.y * 0.9f, color.z * 0.9f, 0.65f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, color);
   }
 
-  nfdu8char_t* outPath = nullptr;
-
-  const nfdopendialogu8args_t args {
-    .filterList = filters.data(),
-    .filterCount = static_cast<nfdfiltersize_t>(filters.size())
-  };
-
-  std::optional<std::string> result;
-
-  if (NFD_OpenDialogU8_With(&outPath, &args) == NFD_OKAY)
+  void popButtonStyle()
   {
-    result = outPath;
-    NFD_FreePathU8(outPath);
+    ImGui::PopStyleColor(3);
   }
 
-  NFD_Quit();
-  return result;
-}
-
-bool nameIsValid(const std::string& name)
-{
-  if (name.empty())
+  void labeledSeparator(const char* label)
   {
-    return false;
+    ImGui::Spacing();
+    ImGui::TextColored(kColorSubtle, "%s", label);
+    ImGui::Separator();
+    ImGui::Spacing();
   }
 
-  return std::ranges::none_of(name, [](const char c) {
-    return c == '/' || c == '\\' || c == ':' || c == '*' || c == '?' || c == '"' || c == '<' || c == '>' || c == '|';
-  });
+  std::optional<std::string> openFileDialog(const std::vector<nfdu8filteritem_t>& filters)
+  {
+    if (NFD_Init() != NFD_OKAY)
+    {
+      throw std::runtime_error("NFD_Init failed");
+    }
+
+    nfdu8char_t* outPath = nullptr;
+
+    const nfdopendialogu8args_t args {
+      .filterList = filters.data(),
+      .filterCount = static_cast<nfdfiltersize_t>(filters.size())
+    };
+
+    std::optional<std::string> result;
+
+    if (NFD_OpenDialogU8_With(&outPath, &args) == NFD_OKAY)
+    {
+      result = outPath;
+      NFD_FreePathU8(outPath);
+    }
+
+    NFD_Quit();
+    return result;
+  }
+
+  bool nameIsValid(const std::string& name)
+  {
+    if (name.empty())
+    {
+      return false;
+    }
+
+    return std::ranges::none_of(name, [](const char c) {
+      return c == '/' || c == '\\' || c == ':' || c == '*' || c == '?' || c == '"' || c == '<' || c == '>' || c == '|';
+    });
+  }
 }
 
 AssetManager::AssetManager(ECS3D* ecs)

--- a/source/assets/AssetManager.cpp
+++ b/source/assets/AssetManager.cpp
@@ -7,9 +7,74 @@
 #include "../objects/Object.h"
 #include "../objects/ObjectManager.h"
 #include <imgui.h>
+#include <nfd.h>
 #include <nlohmann/json.hpp>
 #include <VulkanEngine/components/window/Window.h>
+#include <filesystem>
+#include <fstream>
 #include <ranges>
+
+constexpr ImVec4 kColorSubtle   { 0.55f, 0.55f, 0.55f, 1.00f };
+constexpr ImVec4 kColorAccent   { 0.40f, 0.72f, 1.00f, 1.00f };
+constexpr ImVec4 kColorWarning  { 1.00f, 0.75f, 0.20f, 1.00f };
+constexpr ImVec4 kColorDanger   { 0.95f, 0.35f, 0.35f, 1.00f };
+constexpr ImVec4 kColorSuccess  { 0.35f, 0.85f, 0.55f, 1.00f };
+
+void pushButtonStyle(const ImVec4 color)
+{
+  ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(color.x * 0.7f, color.y * 0.7f, color.z * 0.7f, 0.45f));
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(color.x * 0.9f, color.y * 0.9f, color.z * 0.9f, 0.65f));
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, color);
+}
+
+void popButtonStyle()
+{
+  ImGui::PopStyleColor(3);
+}
+
+void labeledSeparator(const char* label)
+{
+  ImGui::Spacing();
+  ImGui::TextColored(kColorSubtle, "%s", label);
+  ImGui::Separator();
+  ImGui::Spacing();
+}
+
+std::optional<std::string> openFileDialog(const std::vector<nfdu8filteritem_t>& filters)
+{
+  if (NFD_Init() != NFD_OKAY)
+    throw std::runtime_error("NFD_Init failed");
+
+  nfdu8char_t* outPath = nullptr;
+
+  const nfdopendialogu8args_t args {
+    .filterList = filters.data(),
+    .filterCount = static_cast<nfdfiltersize_t>(filters.size())
+  };
+
+  std::optional<std::string> result;
+
+  if (NFD_OpenDialogU8_With(&outPath, &args) == NFD_OKAY)
+  {
+    result = outPath;
+    NFD_FreePathU8(outPath);
+  }
+
+  NFD_Quit();
+  return result;
+}
+
+bool nameIsValid(const std::string& name)
+{
+  if (name.empty())
+  {
+    return false;
+  }
+
+  return std::ranges::none_of(name, [](const char c) {
+    return c == '/' || c == '\\' || c == ':' || c == '*' || c == '?' || c == '"' || c == '<' || c == '>' || c == '|';
+  });
+}
 
 AssetManager::AssetManager(ECS3D* ecs)
   : m_ecs(ecs)
@@ -18,6 +83,296 @@ AssetManager::AssetManager(ECS3D* ecs)
 ECS3D* AssetManager::getECS() const
 {
   return m_ecs;
+}
+
+void AssetManager::displayMenuWidget()
+{
+  static PendingAsset pending;
+  static bool openPopup = false;
+  static std::string errorMessage;
+
+  auto triggerImport = [&](const PendingAsset::Type type,
+                           const std::vector<nfdu8filteritem_t>& filters)
+  {
+    const auto picked = openFileDialog(filters);
+    if (!picked)
+    {
+      return;
+    }
+
+    pending.type = type;
+    pending.path = *picked;
+    pending.name = std::filesystem::path(pending.path).stem().string();
+    errorMessage.clear();
+    openPopup = true;
+  };
+
+  auto triggerCreate = [&](const PendingAsset::Type type,
+                           const char* defaultName)
+  {
+    pending.type = type;
+    pending.path.clear();
+    pending.name = defaultName;
+    errorMessage.clear();
+    openPopup = true;
+  };
+
+  if (ImGui::BeginMenu("Assets"))
+  {
+    labeledSeparator("Import");
+
+    if (ImGui::MenuItem("Import Model"))
+    {
+      triggerImport(PendingAsset::Type::Model, {{ "3D Models", "obj,gltf,glb,fbx" }});
+    }
+
+    if (ImGui::MenuItem("Import Texture"))
+    {
+      triggerImport(PendingAsset::Type::Texture, {{ "Images", "png,jpg,jpeg,tga,bmp" }});
+    }
+
+    labeledSeparator("Create");
+
+    if (ImGui::MenuItem("New Scene"))
+    {
+      triggerCreate(PendingAsset::Type::Scene, "NewScene");
+    }
+
+    if (ImGui::MenuItem("New Script"))
+    {
+      triggerCreate(PendingAsset::Type::Script, "NewScript");
+    }
+
+    ImGui::EndMenu();
+  }
+
+  if (openPopup)
+  {
+    ImGui::OpenPopup("###CreateAssetModal");
+    openPopup = false;
+  }
+
+  displayCreateAssetPopup(pending, errorMessage);
+}
+
+void AssetManager::displayCreateAssetPopup(PendingAsset& pending, std::string& errorMessage)
+{
+  const std::string title = " Create " + pending.toString() + "###CreateAssetModal";
+
+  ImGui::SetNextWindowSize(ImVec2(420, 0), ImGuiCond_Always);
+
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,  ImVec2(18, 16));
+  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,    ImVec2(8, 10));
+  ImGui::PushStyleVar(ImGuiStyleVar_FramePadding,   ImVec2(8, 6));
+  ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,  4.0f);
+  ImGui::PushStyleVar(ImGuiStyleVar_PopupRounding,  6.0f);
+
+  if (!ImGui::BeginPopupModal(title.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+  {
+    ImGui::PopStyleVar(5);
+    return;
+  }
+
+  displayPopupSourcePath(pending);
+  displayPopupNameInput(pending, errorMessage);
+
+  if (!errorMessage.empty())
+  {
+    ImGui::Spacing();
+    ImGui::TextColored(kColorDanger, "%s", errorMessage.c_str());
+  }
+
+  ImGui::Spacing();
+  ImGui::Separator();
+  ImGui::Spacing();
+
+  displayPopupActionButtons(pending, errorMessage);
+
+  ImGui::EndPopup();
+  ImGui::PopStyleVar(5);
+}
+
+void AssetManager::displayPopupSourcePath(const PendingAsset& pending)
+{
+  if (!pending.requiresFilePicker()) return;
+
+  ImGui::TextColored(kColorSubtle, "Source");
+
+  const std::string display = pending.path.empty()
+    ? "(no file selected)"
+    : std::filesystem::path(pending.path).filename().string();
+
+  ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.12f, 0.12f, 0.12f, 1.0f));
+  ImGui::BeginChild("##sourcepath", ImVec2(-1, 28), false);
+  ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 4.0f);
+
+  if (pending.path.empty())
+    ImGui::TextColored(kColorWarning, "%s", display.c_str());
+  else
+    ImGui::TextColored(kColorSuccess, "%s", display.c_str());
+
+  ImGui::EndChild();
+  ImGui::PopStyleColor();
+  ImGui::Spacing();
+}
+
+void AssetManager::displayPopupNameInput(PendingAsset& pending, std::string& errorMessage)
+{
+  ImGui::TextColored(kColorSubtle, "Asset Name");
+
+  char nameBuf[128] = {};
+  const size_t copyLen = std::min(pending.name.size(), sizeof(nameBuf) - 1);
+  std::memcpy(nameBuf, pending.name.data(), copyLen);
+
+  const bool nameInvalid = !nameIsValid(pending.name);
+
+  if (nameInvalid)
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.35f, 0.10f, 0.10f, 1.0f));
+
+  ImGui::SetNextItemWidth(-1);
+  if (ImGui::InputText("##assetname", nameBuf, sizeof(nameBuf)))
+  {
+    pending.name = nameBuf;
+    errorMessage.clear();
+  }
+
+  if (nameInvalid)
+    ImGui::PopStyleColor();
+}
+
+void AssetManager::displayPopupActionButtons(PendingAsset& pending, std::string& errorMessage)
+{
+  const bool canCreate = pending.isValid() && nameIsValid(pending.name) &&
+                         (!pending.requiresFilePicker() || !pending.path.empty());
+
+  if (!canCreate)
+    ImGui::BeginDisabled();
+
+  pushButtonStyle(kColorAccent);
+  if (ImGui::Button("Create", ImVec2(180, 0)))
+  {
+    try
+    {
+      commitAssetCreation(pending);
+      ImGui::CloseCurrentPopup();
+    }
+    catch (const std::exception& e)
+    {
+      errorMessage = e.what();
+    }
+  }
+  popButtonStyle();
+
+  if (!canCreate)
+    ImGui::EndDisabled();
+
+  ImGui::SameLine();
+
+  pushButtonStyle(kColorSubtle);
+  if (ImGui::Button("Cancel", ImVec2(180, 0)))
+  {
+    pending = {};
+    errorMessage.clear();
+    ImGui::CloseCurrentPopup();
+  }
+  popButtonStyle();
+}
+
+void AssetManager::commitAssetCreation(const PendingAsset& pending)
+{
+  const bool nameExists = std::ranges::any_of(m_assets, [&](const auto& pair) {
+    return pair.second->getName() == pending.name;
+  });
+
+  if (nameExists)
+  {
+    throw std::runtime_error("An asset named \"" + pending.name + "\" already exists.");
+  }
+
+  switch (pending.type)
+  {
+    case PendingAsset::Type::Model: commitModelAsset(pending.name, pending.path); break;
+    case PendingAsset::Type::Texture: commitTextureAsset(pending.name, pending.path); break;
+    case PendingAsset::Type::Scene: commitSceneAsset(pending.name); break;
+    case PendingAsset::Type::Script: commitScriptAsset(pending.name); break;
+    default: break;
+  }
+
+  m_shouldComputeFilteredAssets = true;
+}
+
+void AssetManager::commitModelAsset(const std::string& name, const std::string& srcPath)
+{
+  const std::filesystem::path dstDir = "assets/models/";
+  std::filesystem::create_directories(dstDir);
+
+  const std::filesystem::path dstPath = dstDir / (name + std::filesystem::path(srcPath).extension().string());
+  std::filesystem::copy_file(srcPath, dstPath, std::filesystem::copy_options::none);
+
+  const std::string finalPath = dstPath.string();
+
+  auto uuid = m_ecs->createUUID();
+  auto asset = std::make_shared<ModelAsset>(uuid, finalPath);
+  asset->setManager(this);
+  asset->load();
+
+  m_assets.emplace(uuid, asset);
+  m_loadedPaths.emplace(finalPath, uuid);
+}
+
+void AssetManager::commitTextureAsset(const std::string& name, const std::string& srcPath)
+{
+  const std::filesystem::path dstDir = "assets/textures/";
+  std::filesystem::create_directories(dstDir);
+
+  const std::filesystem::path dstPath = dstDir / (name + std::filesystem::path(srcPath).extension().string());
+  std::filesystem::copy_file(srcPath, dstPath, std::filesystem::copy_options::none);
+
+  const std::string finalPath = dstPath.string();
+
+  auto uuid = m_ecs->createUUID();
+  auto asset = std::make_shared<TextureAsset>(uuid, finalPath);
+  asset->setManager(this);
+  asset->load();
+
+  m_assets.emplace(uuid, asset);
+  m_loadedPaths.emplace(finalPath, uuid);
+}
+
+void AssetManager::commitSceneAsset(const std::string& name)
+{
+  std::filesystem::create_directories("assets/scenes/");
+  const std::filesystem::path path = "assets/scenes/" + name + ".json";
+
+  const nlohmann::json data = {
+    { "uuid", uuids::to_string(m_ecs->createUUID()) },
+    { "name", name },
+    { "objects", nlohmann::json::array() }
+  };
+
+  std::ofstream(path) << data.dump(2);
+  createSceneAsset(name);
+}
+
+void AssetManager::commitScriptAsset(const std::string& name)
+{
+  std::filesystem::create_directories("scripts/userScripts/");
+  const std::filesystem::path path = "scripts/userScripts/" + name + ".cs";
+
+  std::ofstream out(path);
+  out <<
+    "using System;\n"
+    "using System.Numerics;\n"
+    "using ScriptBridge;\n\n"
+    "public class " << name << " : ScriptBase\n"
+    "{\n"
+    "    public override void start() {}\n"
+    "    public override void fixedUpdate(float dt) {}\n"
+    "    public override void variableUpdate() {}\n"
+    "    public override void stop() {}\n"
+    "}\n";
+
+  loadScriptAsset(path.string(), name);
 }
 
 void AssetManager::displayGui()
@@ -32,7 +387,7 @@ void AssetManager::displayGui()
   const float scaledCellSize = cellSize * m_ecs->getRenderer()->getWindow()->getContentScale();
   const float width = ImGui::GetContentRegionAvail().x;
 
-  ImGui::Columns(std::max(1, static_cast<int>(width / scaledCellSize)), 0, false);
+  ImGui::Columns(std::max(1, static_cast<int>(width / scaledCellSize)), nullptr, false);
 
   for (const auto& asset : m_filteredAssets)
   {
@@ -70,7 +425,7 @@ std::shared_ptr<SceneAsset> AssetManager::createSceneAsset(std::string name)
   return asset;
 }
 
-void AssetManager::loadScriptAsset(std::string path,
+void AssetManager::loadScriptAsset(const std::string& path,
                                    std::string className)
 {
   if (m_loadedPaths.contains(path))
@@ -143,7 +498,7 @@ void AssetManager::displayAssetsFilterGui()
     ImGui::Spacing();
 
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Filter: ");
+    ImGui::TextColored(kColorSubtle, "Filter:");
     for (const auto& [type, typeStr] : assetTypeToString)
     {
       bool selected = m_filteredAssetType == type;
@@ -162,7 +517,7 @@ void AssetManager::displayAssetsFilterGui()
     m_searchQuery.copy(searchBuf, sizeof(searchBuf) - 1);
 
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Search: ");
+    ImGui::TextColored(kColorSubtle, "Search:");
     ImGui::SameLine();
     if (ImGui::InputText("##Search", searchBuf, sizeof(searchBuf)))
     {
@@ -172,22 +527,18 @@ void AssetManager::displayAssetsFilterGui()
     }
 
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Sort: ");
+    ImGui::TextColored(kColorSubtle, "Sort:");
     ImGui::SameLine();
     if (ImGui::BeginCombo("##SortCombo", sortTypeToString.at(m_sortType).c_str()))
     {
-      if (ImGui::Selectable(sortTypeToString.at(SortType::nameAscending).c_str(), m_sortType == SortType::nameAscending))
+      for (const auto type : { SortType::nameAscending, SortType::nameDescending })
       {
-        m_sortType = SortType::nameAscending;
+        if (ImGui::Selectable(sortTypeToString.at(type).c_str(), m_sortType == type))
+        {
+          m_sortType = type;
 
-        m_shouldComputeFilteredAssets = true;
-      }
-
-      if (ImGui::Selectable(sortTypeToString.at(SortType::nameDescending).c_str(), m_sortType == SortType::nameDescending))
-      {
-        m_sortType = SortType::nameDescending;
-
-        m_shouldComputeFilteredAssets = true;
+          m_shouldComputeFilteredAssets = true;
+        }
       }
 
       ImGui::EndCombo();
@@ -232,18 +583,10 @@ void AssetManager::computeFilteredAssets()
   }
 
   std::ranges::sort(m_filteredAssets, [this](const auto& a, const auto& b) {
-    return std::ranges::lexicographical_compare(a->getName(), b->getName(), [this](const char x, const char y) {
-      if (m_sortType == SortType::nameAscending)
-      {
-        return std::tolower(x) < std::tolower(y);
-      }
-
-      if (m_sortType == SortType::nameDescending)
-      {
-        return std::tolower(x) > std::tolower(y);
-      }
-
-      return true;
+    return std::ranges::lexicographical_compare( a->getName(), b->getName(), [this](char x, char y) {
+      return m_sortType == SortType::nameAscending
+        ? std::tolower(x) < std::tolower(y)
+        : std::tolower(x) > std::tolower(y);
     });
   });
 

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -51,7 +51,7 @@ enum class SortType {
   nameDescending
 };
 
-inline const std::unordered_map<SortType, std::string> sortTypeToString {
+inline std::unordered_map<SortType, std::string> sortTypeToString {
   { SortType::nameAscending, "Name (A-Z)" },
   { SortType::nameDescending, "Name (Z-A)" },
 };

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -131,7 +131,7 @@ private:
 
   void commitSceneAsset(std::string name);
 
-  void commitScriptAsset(const std::string& name);
+  void commitScriptAsset(std::string name);
 };
 
 template<typename T>

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -113,7 +113,8 @@ private:
 
   void loadScriptsFromJSON(const nlohmann::json& assetsData);
 
-  void displayCreateAssetPopup(PendingAsset& pending, std::string& errorMessage);
+  void displayCreateAssetPopup(PendingAsset& pending,
+                               std::string& errorMessage);
 
   static void displayPopupSourcePath(const PendingAsset& pending);
 

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -15,8 +15,7 @@ class ModelAsset;
 class SceneAsset;
 class TextureAsset;
 
-struct PendingAsset
-{
+struct PendingAsset {
   enum class Type { None, Model, Texture, Scene, Script };
 
   Type type = Type::None;

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -131,7 +131,7 @@ private:
   void commitTextureAsset(const std::string& name,
                           const std::string& srcPath);
 
-  void commitSceneAsset(const std::string& name);
+  void commitSceneAsset(std::string name);
 
   void commitScriptAsset(const std::string& name);
 };

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -15,6 +15,37 @@ class ModelAsset;
 class SceneAsset;
 class TextureAsset;
 
+struct PendingAsset
+{
+  enum class Type { None, Model, Texture, Scene, Script };
+
+  Type type = Type::None;
+  std::string path;
+  std::string name;
+
+  [[nodiscard]] bool isValid() const
+  {
+    return type != Type::None && !name.empty();
+  }
+
+  [[nodiscard]] bool requiresFilePicker() const
+  {
+    return type == Type::Model || type == Type::Texture;
+  }
+
+  [[nodiscard]] std::string toString() const
+  {
+    switch (type)
+    {
+      case Type::Model: return "3D Model";
+      case Type::Texture: return "Texture";
+      case Type::Scene: return "Scene";
+      case Type::Script: return "Script";
+      default: return "";
+    }
+  }
+};
+
 enum class SortType {
   nameAscending,
   nameDescending
@@ -31,11 +62,13 @@ public:
 
   [[nodiscard]] ECS3D* getECS() const;
 
+  void displayMenuWidget();
+
   void displayGui();
 
   [[nodiscard]] std::shared_ptr<SceneAsset> createSceneAsset(std::string name);
 
-  void loadScriptAsset(std::string path,
+  void loadScriptAsset(const std::string& path,
                        std::string className);
 
   template <typename T>
@@ -79,6 +112,16 @@ private:
   void loadScenesFromJSON(const nlohmann::json& assetsData);
 
   void loadScriptsFromJSON(const nlohmann::json& assetsData);
+
+  void displayCreateAssetPopup(PendingAsset& pending, std::string& errorMessage);
+  static void displayPopupSourcePath(const PendingAsset& pending);
+  static void displayPopupNameInput(PendingAsset& pending, std::string& errorMessage);
+  void displayPopupActionButtons(PendingAsset& pending, std::string& errorMessage);
+  void commitAssetCreation(const PendingAsset& pending);
+  void commitModelAsset(const std::string& name, const std::string& srcPath);
+  void commitTextureAsset(const std::string& name, const std::string& srcPath);
+  void commitSceneAsset(const std::string& name);
+  void commitScriptAsset(const std::string& name);
 };
 
 template<typename T>

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -11,9 +11,7 @@
 
 class Asset;
 class ECS3D;
-class ModelAsset;
 class SceneAsset;
-class TextureAsset;
 
 struct PendingAsset {
   enum class Type { None, Model, Texture, Scene, Script };

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -48,7 +48,7 @@ enum class SortType {
   NameDescending
 };
 
-inline std::unordered_map<SortType, std::string> sortTypeToString {
+inline const std::unordered_map<SortType, std::string> sortTypeToString {
   { SortType::NameAscending, "Name (A-Z)" },
   { SortType::NameDescending, "Name (Z-A)" },
 };

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -47,13 +47,13 @@ struct PendingAsset
 };
 
 enum class SortType {
-  nameAscending,
-  nameDescending
+  NameAscending,
+  NameDescending
 };
 
 inline std::unordered_map<SortType, std::string> sortTypeToString {
-  { SortType::nameAscending, "Name (A-Z)" },
-  { SortType::nameDescending, "Name (Z-A)" },
+  { SortType::NameAscending, "Name (A-Z)" },
+  { SortType::NameDescending, "Name (Z-A)" },
 };
 
 class AssetManager {
@@ -97,7 +97,7 @@ private:
 
   std::vector<std::shared_ptr<Asset>> m_filteredAssets;
 
-  SortType m_sortType = SortType::nameAscending;
+  SortType m_sortType = SortType::NameAscending;
 
   bool m_shouldComputeFilteredAssets = true;
 

--- a/source/assets/AssetManager.h
+++ b/source/assets/AssetManager.h
@@ -114,13 +114,25 @@ private:
   void loadScriptsFromJSON(const nlohmann::json& assetsData);
 
   void displayCreateAssetPopup(PendingAsset& pending, std::string& errorMessage);
+
   static void displayPopupSourcePath(const PendingAsset& pending);
-  static void displayPopupNameInput(PendingAsset& pending, std::string& errorMessage);
-  void displayPopupActionButtons(PendingAsset& pending, std::string& errorMessage);
+
+  static void displayPopupNameInput(PendingAsset& pending,
+                                    std::string& errorMessage);
+
+  void displayPopupActionButtons(PendingAsset& pending,
+                                 std::string& errorMessage);
+
   void commitAssetCreation(const PendingAsset& pending);
-  void commitModelAsset(const std::string& name, const std::string& srcPath);
-  void commitTextureAsset(const std::string& name, const std::string& srcPath);
+
+  void commitModelAsset(const std::string& name,
+                        const std::string& srcPath);
+
+  void commitTextureAsset(const std::string& name,
+                          const std::string& srcPath);
+
   void commitSceneAsset(const std::string& name);
+
   void commitScriptAsset(const std::string& name);
 };
 


### PR DESCRIPTION
This pull request introduces enhancements to asset management and UI in the application, focusing on improved asset creation workflows and code clarity. The main changes include a new `PendingAsset` struct to streamline asset creation, refactoring of sorting logic, and the addition of several helper methods for asset creation popups and actions.

**Asset creation workflow improvements:**

* Added a `PendingAsset` struct to encapsulate all data and logic related to an asset being created, including type, path, name, and helper methods for validation and UI display. This centralizes asset creation state and behavior.
* Introduced several methods to `AssetManager` for managing the asset creation popup UI and committing new assets: `displayCreateAssetPopup`, `displayPopupSourcePath`, `displayPopupNameInput`, `displayPopupActionButtons`, and asset commit methods for each asset type.

**UI integration:**

* Added a call to `m_assetManager->displayMenuWidget()` in `ECS3D::displayMenuBar()`, integrating the new asset creation UI into the main menu bar.
* Exposed a new `displayMenuWidget` method in `AssetManager` for rendering asset-related menu widgets.

**Code clarity and refactoring:**

* Refactored `SortType` enum values to use PascalCase (`NameAscending`, `NameDescending`) and updated the associated `sortTypeToString` map for consistency and clarity. [[1]](diffhunk://#diff-093a89f1b07c7b03d41a6001eab69a1e8d943d0c574dffffba025d9147f5e849L14-R53) [[2]](diffhunk://#diff-093a89f1b07c7b03d41a6001eab69a1e8d943d0c574dffffba025d9147f5e849L67-R97)
* Changed the `loadScriptAsset` method to take a `const std::string&` for the path parameter, improving const-correctness.

These changes collectively improve the user experience for creating assets and make the codebase more maintainable and consistent.