### PR TITLE
Remove ImGui dockspace from client application

### DIFF
--- a/source/apps/client/ClientApp.cpp
+++ b/source/apps/client/ClientApp.cpp
@@ -152,6 +152,7 @@ void ClientApp::createRenderer()
       .position = { 0, 5, -50 }
     },
     .imGui {
+      .useDockspace = false,
       .maxTextures = 100
     }
   };


### PR DESCRIPTION
This pull request makes a small configuration change to the `createRenderer` method in `ClientApp.cpp`. The change disables the use of ImGui dockspace in the renderer settings.

* Disabled ImGui dockspace by setting `.useDockspace = false` in the renderer configuration within `ClientApp::createRenderer`.