### PR TITLE
Add dynamic raytracing toggle and reflectivity support to ModelRenderer

### DIFF
--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -602,6 +602,25 @@ void EditorApp::displaySceneStatus() const
     ImGui::EndDisabled();
   }
 
+  // Ray tracing toggle: a local render setting (this view's vke renderer only, never replicated), so
+  // it stays enabled on a read-only server. Greyed out when the device can't ray trace.
+  const auto renderingManager = m_renderer->getRenderingManager();
+  ImGui::SameLine(0.0f, 18.0f);
+  ImGui::BeginDisabled(!renderingManager->supportsRayTracing());
+  bool rayTracing = renderingManager->isRayTracingEnabled();
+  if (gc::accentCheckboxCompact("Ray Tracing", &rayTracing))
+  {
+    if (rayTracing)
+    {
+      renderingManager->enableRayTracing();
+    }
+    else
+    {
+      renderingManager->disableRayTracing();
+    }
+  }
+  ImGui::EndDisabled();
+
   // Status readout (divider + dot/label + scene name), right-aligned to the panel edge so the play
   // buttons stay put on the left regardless of the readout's width.
   const char* label = m_sceneStatus == SceneStatus::running ? "Running"

--- a/source/libs/data/objects/components/ModelRenderer.cpp
+++ b/source/libs/data/objects/components/ModelRenderer.cpp
@@ -26,6 +26,16 @@ void ModelRenderer::setUseStandardPipeline(const bool useStandardPipeline)
   m_useStandardPipeline = useStandardPipeline;
 }
 
+float ModelRenderer::getReflectivity() const
+{
+  return m_reflectivity;
+}
+
+void ModelRenderer::setReflectivity(const float reflectivity)
+{
+  m_reflectivity = reflectivity;
+}
+
 uuids::uuid ModelRenderer::getModelUUID() const
 {
   return m_modelUUID;
@@ -66,6 +76,8 @@ nlohmann::json ModelRenderer::serialize()
   const nlohmann::json data = {
     { "type", "ModelRenderer" },
     { "shouldRender", m_shouldRender },
+    { "useStandardPipeline", m_useStandardPipeline },
+    { "reflectivity", m_reflectivity },
     { "modelUUID", m_modelUUID.is_nil() ? "" : uuids::to_string(m_modelUUID) },
     { "textureUUID", m_textureUUID.is_nil() ? "" : uuids::to_string(m_textureUUID) },
     { "specularMapUUID", m_specularMapUUID.is_nil() ? "" : uuids::to_string(m_specularMapUUID) }
@@ -77,6 +89,10 @@ nlohmann::json ModelRenderer::serialize()
 void ModelRenderer::loadFromJSON(const nlohmann::json& componentData)
 {
   m_shouldRender = componentData.at("shouldRender");
+
+  // value() with defaults: these fields are absent from projects saved before they existed.
+  m_useStandardPipeline = componentData.value("useStandardPipeline", true);
+  m_reflectivity = componentData.value("reflectivity", 0.0f);
 
   if (const auto modelUUID = uuids::uuid::from_string(std::string(componentData.at("modelUUID"))); modelUUID.has_value())
   {
@@ -100,6 +116,7 @@ void ModelRenderer::pack(net::Message& message) const
 
   message.write(m_shouldRender);
   message.write(m_useStandardPipeline);
+  message.write(m_reflectivity);
 
   message.write(m_modelUUID);
   message.write(m_textureUUID);
@@ -110,6 +127,7 @@ void ModelRenderer::unpack(net::MessageReader& messageReader)
 {
   m_shouldRender = messageReader.read<bool>();
   m_useStandardPipeline = messageReader.read<bool>();
+  m_reflectivity = messageReader.read<float>();
 
   m_modelUUID = messageReader.read<uuids::uuid>();
   m_textureUUID = messageReader.read<uuids::uuid>();

--- a/source/libs/data/objects/components/ModelRenderer.h
+++ b/source/libs/data/objects/components/ModelRenderer.h
@@ -14,6 +14,9 @@ public:
   [[nodiscard]] bool getUseStandardPipeline() const;
   void setUseStandardPipeline(bool useStandardPipeline);
 
+  [[nodiscard]] float getReflectivity() const;
+  void setReflectivity(float reflectivity);
+
   [[nodiscard]] uuids::uuid getModelUUID() const;
   void setModelUUID(const uuids::uuid& modelUUID);
 
@@ -36,6 +39,8 @@ public:
 private:
   bool m_shouldRender = false;
   bool m_useStandardPipeline = true;
+
+  float m_reflectivity = 0.0f;
 
   uuids::uuid m_modelUUID;
   uuids::uuid m_textureUUID;

--- a/source/libs/editor/components/ModelRendererEditor.cpp
+++ b/source/libs/editor/components/ModelRendererEditor.cpp
@@ -99,6 +99,13 @@ void registerModelRendererEditor(ComponentEditor& componentEditor,
         edited = true;
       }
 
+      float reflectivity = modelRenderer->getReflectivity();
+      if (gc::accentSlider("Reflectivity", &reflectivity, 0.0f, 1.0f))
+      {
+        modelRenderer->setReflectivity(reflectivity);
+        edited = true;
+      }
+
       ImGui::Spacing();
 
       // Drag an asset out of the AssetBrowserPanel onto these slots to assign it.

--- a/source/libs/render/RenderSystem.cpp
+++ b/source/libs/render/RenderSystem.cpp
@@ -48,6 +48,7 @@ void RenderSystem::variableUpdate(const ObjectManager& objectManager, GpuAssetCa
         renderObject->setPosition(transform->getPosition());
         renderObject->setScale(transform->getScale());
         renderObject->setOrientationEuler(transform->getRotation());
+        renderObject->setReflectivity(modelRenderer->getReflectivity());
 
         // pointer is stable: unordered_map keeps element references valid across rehash.
         renderer->getRenderingManager()->getRenderer3D()->renderObject(


### PR DESCRIPTION
This pull request adds support for a new "reflectivity" property to the `ModelRenderer` component, allowing users to control the reflectivity of models in the editor and at runtime. It also introduces a UI toggle for ray tracing in the editor, and ensures the new property is properly serialized, deserialized, and synchronized across the network. The most important changes are summarized below.

### Reflectivity Property Integration

* Added a `reflectivity` float property to `ModelRenderer`, with getter and setter methods, and updated the class definition and member variables to support it (`ModelRenderer.h`, `ModelRenderer.cpp`). [[1]](diffhunk://#diff-652bff10df0666ff2b584c3e9260a6386838ee029276d3b2e943b76d44d34c26R17-R19) [[2]](diffhunk://#diff-652bff10df0666ff2b584c3e9260a6386838ee029276d3b2e943b76d44d34c26R43-R44) [[3]](diffhunk://#diff-4ec91783aafa06af606f49dcb3633373040308eaddbe02e418572a7426467571R29-R38)
* Integrated `reflectivity` into serialization, deserialization, and network synchronization: included the property in JSON serialization/deserialization and in network pack/unpack methods (`ModelRenderer.cpp`). [[1]](diffhunk://#diff-4ec91783aafa06af606f49dcb3633373040308eaddbe02e418572a7426467571R79-R80) [[2]](diffhunk://#diff-4ec91783aafa06af606f49dcb3633373040308eaddbe02e418572a7426467571R93-R96) [[3]](diffhunk://#diff-4ec91783aafa06af606f49dcb3633373040308eaddbe02e418572a7426467571R119) [[4]](diffhunk://#diff-4ec91783aafa06af606f49dcb3633373040308eaddbe02e418572a7426467571R130)
* Updated the editor UI to allow users to adjust the reflectivity value using a slider (`ModelRendererEditor.cpp`).
* Ensured the `reflectivity` value is passed to the rendering system each frame so it can affect rendering (`RenderSystem.cpp`).

### Editor UI Improvements

* Added a ray tracing toggle to the editor scene status panel, which is enabled only if the device supports ray tracing (`EditorApp.cpp`).