### PR TITLE
Create AGENTS documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,161 @@
+# AGENTS.md
+
+> **Living document.** Keep this current. When architecture, conventions, workflows, dependencies, or
+> repository structure change, update this file in the same change. Keep it concise (target 2–5 pages) —
+> summarize systems and link to code; don't duplicate what file names, CMake, or source already make obvious.
+> Read this before making changes.
+
+## Project Overview
+
+- **ECS3D** is a 3D game engine built around a data-oriented Entity Component System, rendered by the
+  **VulkanEngine** library (a sibling project, [SharkFinPro/VulkanRenderer](https://github.com/SharkFinPro/VulkanRenderer),
+  fetched via CMake `FetchContent`, tag `main`).
+- The engine is **authoritative client/server multiplayer** by design. A headless server owns the
+  simulation; clients render a replicated view and send input. Singleplayer is the same server spawned
+  as a local child process. This is not an add-on — it is the shape of the whole codebase.
+- The C++ side owns the engine; **C# is hosted in-process via CoreCLR** (nethost/hostfxr) for two
+  purposes: gameplay scripting (`ScriptBridge`) and the network transport (`ECS3DNetTransport`). C++
+  owns the data and protocol; C# owns the sockets and user script execution.
+- Four executables ship (see Applications): **ECS3DServer**, **ECS3DClient**, **ECS3DEditor** (all C++),
+  and **ECS3DLauncher** (a standalone C# Avalonia app — see `source/apps/launcher/AGENTS.md`).
+- Scope today: a working editor + play/edit servers with physics (GJK/EPA collision, rigid bodies),
+  C# scripting, asset import, scene management, and full snapshot/delta replication over TCP.
+
+## Repository Structure
+
+| Path | Responsibility |
+|------|----------------|
+| `CMakeLists.txt` (root) | Top-level config: C++23, `bin/` output when top-level, MSVC export-all-symbols. Just `add_subdirectory(source)`. |
+| `source/libs/` | All reusable engine libraries. `libs/CMakeLists.txt` fetches shared deps (json, glm, uuid, nfd, VulkanEngine) and the managed-assembly helpers, then adds each lib. |
+| `source/libs/protocol/` | `ECS3DNetProtocol` (INTERFACE lib): `Protocol.h` — the wire format (`MessageType`, `Message`/`MessageReader` binary framing, `Role`, ports). Depended on by everything that touches the wire. |
+| `source/libs/data/` | `ECS3DData` — the foundation. Component **data** (Transform, RigidBody, ModelRenderer, LightRenderer, Colliders, Script), `Object`/`ObjectManager`, scenes, `AssetRegistry`, `ComponentRegistry`, `ProjectSerializer` (JSON file save/load) / `ProjectPacker` (binary wire snapshot), `Replication`. **No Vulkan, no ImGui.** |
+| `source/libs/sim/` | `ECS3DSim` — `PhysicsSystem` (integration, forces, response) and `CollisionSystem` (sweep-and-prune + GJK/EPA under `collisions/`). Operates on `ECS3DData` via accessors. OpenMP if available. |
+| `source/libs/render/` | `ECS3DRender` — `RenderSystem` (draws models/lights, pick feedback, selection highlight, collider gizmos), `GpuAssetCache` (UUID → `vke` GPU objects), `InputCapture`. Depends on `ECS3DData` + `VulkanEngine`. |
+| `source/libs/editor/` | `ECS3DEditorLib` — ImGui editing UI: `ComponentEditor` (per-type handlers), `ObjectGUIManager` (object tree + inspector), `AssetBrowserPanel`, `SaveUI`, `GuiComponents`. Depends on `ECS3DData` + `ECS3DRender` + `nfd`. |
+| `source/libs/net/` | `ECS3DNet` — `NetServer`/`NetClient`/`MessageQueue`/`ServerProcess` (C++), plus the `Transport/` C# assembly (`ECS3DNetTransport`, TCP + WebSocket backends). |
+| `source/libs/scripting/` | `ECS3DScripting` — `ScriptSystem`/`ScriptEngine` + native `bindings/` (Transform, RigidBody, InputUtils; `InputState`), plus the `ScriptBridge/` C# assembly and example `UserScripts/`. |
+| `source/libs/clrHost/` | `ECS3DClrHost` — `ManagedHost` boots CoreCLR and hands out managed statics as native fn ptrs. Owns the CMake helpers (`cmake/ECS3DManaged.cmake`, `FindDotnet.cmake`, `loadCS.cmake`). |
+| `source/apps/` | The executables. `apps/CMakeLists.txt` orders them (server first — client/editor depend on it). |
+| `source/apps/{server,client,editor}/` | The three C++ apps: a thin `main.cpp` (argv parsing) + a `*App` class. |
+| `source/apps/launcher/` | The standalone C# Avalonia launcher. **Has its own `AGENTS.md`** — treat it as an independent project. |
+| `.github/workflows/` | `cmake-multi-platform.yml` — builds Release on Windows (MSVC), Linux (gcc+clang), macOS (clang) with the Vulkan SDK, then `ctest`. |
+
+## Build System
+
+- **CMake ≥ 3.29**, **C++23**. Executables land in `bin/` when ECS3D is the top-level project.
+- **Dependencies** (`FetchContent` in `source/libs/CMakeLists.txt`): nlohmann/json 3.12.0, glm 1.0.1,
+  stduuid 1.2.3, nativefiledialog-extended (nfd) 1.3.0, and VulkanEngine (`main`). They are declared at
+  the libs scope so every library links them directly. **glm is declared first, on purpose:**
+  FetchContent is first-wins, and VulkanEngine also fetches glm — our pinned 1.0.1 must be the single
+  copy both sides resolve to. **If VulkanEngine bumps glm, bump the tag here to match.**
+- **.NET 10** is required for the managed assemblies. `ecs3d_add_managed_assembly()` (in
+  `clrHost/cmake/ECS3DManaged.cmake`) `dotnet publish`es a C# class lib next to the executables and
+  writes its `runtimeconfig.json`; `ecs3d_deploy_clr_runtime()` copies `nethost.dll` beside each exe.
+- **Managed assemblies deployed at build time:** `ScriptBridge` → `bin/scripts/ScriptBridge`,
+  `ECS3DNetTransport` → `bin/net/Transport`, user scripts → `bin/scripts/UserScripts`. All apps boot the
+  CLR from the same runtime; the server loads `ScriptBridge` on top.
+- **Runtime CWD = the executable's directory.** Asset paths (`assets/models/...`), managed assembly
+  paths (`net/Transport/...`, `scripts/...`), and `nethost.dll` are all resolved relative to it. The
+  server's `defaultAssets/` are copied into `bin/assets/` at configure time.
+- **Source lists are explicit** in each lib's `CMakeLists.txt` (not globs). **Add new engine files to
+  the owning library's list.**
+- **Dependency direction (must hold):** `protocol` → nothing. `data` → protocol (+ json/glm/uuid).
+  `sim` → data. `render` → data + VulkanEngine. `editor` → data + render + nfd. `net`/`scripting` →
+  data + clrHost. Apps compose these. **`data` must never gain a Vulkan or ImGui include** — that
+  invariant is what keeps the headless server headless.
+
+## Architecture Overview
+
+**The data/systems split.** `ECS3DData` holds only *state* — component fields plus `serialize`/
+`loadFromJSON`. Behavior lives in *systems* that operate on that data from the outside: `PhysicsSystem`/
+`CollisionSystem` (sim), `RenderSystem` (render), `ScriptSystem` (scripting), the `*Editor` handlers
+(editor). A component never reaches back into a manager or renderer; systems iterate
+`ObjectManager::getAllObjects()` and pull the components they care about. `ComponentRegistry`
+(populated by `registerDataComponents()`) is the type-name → factory table that deserialization uses,
+so no layer needs to name concrete component types across the boundary.
+
+**Client / server.** `ServerApp` is authoritative and headless — it is the **only** thing that links
+`ECS3DSim` + `ECS3DScripting`. It runs a fixed-timestep loop (`scriptSystem.variableUpdate` →
+`fixedUpdate` → `physicsSystem` → `collisionSystem`) and streams state out. `ClientApp` renders + sends
+input, linking `ECS3DRender` but never sim/scripting. `EditorApp` is a client plus the ImGui tooling
+(`ECS3DEditorLib`); the authoritative scene lives on a spawned `--edit` server, so edits become
+*commands sent back*, not local mutations. Client/editor spawn a child `ECS3DServer` via `ServerProcess`
+for singleplayer.
+
+**Replication.** Two paths. Structural state (project/scene/assets) goes as a full **snapshot** — a
+packed binary blob built by `ProjectPacker` (the wire counterpart of `ProjectSerializer`, which remains
+the JSON path for file save/load) — sent on join and rebroadcast after any structural edit; every view
+rebuilds from it, atomically (a malformed packet leaves the current project intact). Per-tick motion
+goes as a compact binary **stateDelta** (uuid + local transform per object; `data/Replication.{h,cpp}`).
+Edits flow the other way as typed commands (`editComponent`, `sceneEdit`, `sceneControl`, `loadProject`,
+`addAsset`) that only a connection authorized as `Role::editor` on an `--edit` server may send.
+
+**Transport / CLR.** `Protocol.h` defines the format; `NetServer`/`NetClient` own it in C++ and hand
+`ECS3DNetTransport` (C#) opaque `(type byte, payload)` pairs. `ManagedHost` boots CoreCLR and resolves
+managed statics as native function pointers; inbound frames are pushed from C# socket threads into a
+thread-safe `MessageQueue` and drained by the app loop. The transport backend (TCP/WebSocket) is
+selected by a single field in `Transport.cs`.
+
+**Scripting.** `ScriptSystem` drives `ScriptBridge` (C# gameplay scripts) through `ManagedHost`. Native
+`bindings/` expose Transform/RigidBody/InputUtils to C# via fn-ptr structs. The headless server has no
+GLFW window, so input is networked: clients send `inputState`, the server writes it into the global
+`InputState`, and `InputUtilsBindings` reads it back for scripts. Forces requested from a script are
+buffered on the `RigidBody` data (pending-force queue) and drained by `PhysicsSystem`, keeping
+`scripting` independent of `sim`.
+
+## Development Principles
+
+- **No namespace on ECS3D code** (unlike `vke::` in VulkanEngine). Network code lives in `namespace net`.
+- **Headers:** `#ifndef NAME_H` include guards; forward-declare across libraries and include in the
+  `.cpp` to keep coupling low (see the `*App.h` files — they forward-declare every collaborator).
+- **Naming:** `PascalCase` types/files, `camelCase` methods/locals, `m_` member prefix. `[[nodiscard]]`
+  on getters/queries; prefer `const` accessors.
+- **Ownership:** subsystems are shared via `std::shared_ptr`, passed as `const std::shared_ptr<T>&`.
+  `vke::raii` owns Vulkan handles — never manually destroy.
+- **The serialize/loadFromJSON boundary is the contract.** Replication, save/load, and the registry all
+  ride on it. When you add a component field, thread it through both — and only both; no layer should
+  learn the concrete type.
+- **Respect the layer boundaries.** Put data in `data`, behavior in the matching system, UI in `editor`.
+  Splitting a new component means: fields → `data`, physics → `sim`, rendering → `render`, bindings →
+  `scripting`, inspector widget → `editor`. Register it in `registerDataComponents()`.
+- **Source-list discipline:** every new file goes in its library's `CMakeLists.txt` source list.
+
+## Applications
+
+- **ECS3DServer** (`apps/server`) — headless authoritative sim. `main.cpp` parses `--project`, `--port`,
+  `--edit` (allow editor connections), `--ephemeral` (exit when the last connection drops — a spawned
+  local server), `--token`. Links Data+Sim+Scripting+Net+ClrHost. Ships `defaultAssets/` and generates a
+  built-in `DefaultProject` when no `--project` is given.
+- **ECS3DClient** (`apps/client`) — the lightweight view. `--host`/`--port`/`--project`. Links
+  Data+Render+Net+ClrHost. Spawns a local server for singleplayer; `--host` connects to an existing
+  server instead.
+- **ECS3DEditor** (`apps/editor`) — client + ImGui tooling (object tree, inspector, asset browser, scene
+  controls, save/load). `--host`/`--port`/`--project`/`--token` (edit token when attaching to an existing
+  edit server). By default spawns its own `--edit` server with a generated token. Links
+  Data+Render+EditorLib+Net+ClrHost.
+- **ECS3DLauncher** (`apps/launcher`) — a standalone C# Avalonia project-management GUI. Independent of
+  the C++ toolchain and the CLR-hosting path; built via `dotnet publish`. **See its own `AGENTS.md`.**
+
+## AI Agent Guidelines
+
+- Read this file before changing anything. When touching only the launcher, read
+  `source/apps/launcher/AGENTS.md` instead — it stands alone.
+- Understand the existing split (data vs. systems, client vs. authoritative server, snapshot vs.
+  delta vs. command) before adding to it. Prefer **extending existing systems over parallel ones**.
+- Do not add a Vulkan or ImGui dependency to `ECS3DData`, and do not make the server link
+  render/editor — those invariants keep it headless.
+- Add dependencies only via `source/libs/CMakeLists.txt` `FetchContent`; register new files in the
+  owning library's source list.
+- **The C++/CLR/Vulkan stack generally cannot be build-verified in the agent environment** (no MSVC/
+  Vulkan SDK/.NET). State clearly when a change is unverified and needs to be compiled on the user's
+  machine.
+- Avoid speculative refactors. Keep changes scoped and incremental. Ask about lifetime/ownership,
+  threading, and replication semantics rather than assuming.
+- Update this document when your understanding of the project meaningfully improves.
+
+## Living Document Notice
+
+- AGENTS.md is a **living document** and the primary onboarding reference for AI agents.
+- Reflect significant architectural, structural, workflow, or convention changes here as they happen.
+- Keep it **concise and relevant** rather than letting it grow into a full architecture manual. For deep
+  topics, add a dedicated doc and link it here instead of expanding this file.

--- a/source/apps/launcher/AGENTS.md
+++ b/source/apps/launcher/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md — ECS3D Launcher
+
+> **Living document.** Keep this current. When architecture, conventions, workflows, dependencies, or
+> structure change, update this file in the same change. Keep it concise. Read this before making changes.
+>
+> **This is a standalone project.** The ECS3D Launcher is a self-contained C# / Avalonia desktop app.
+> It shares no code, build step, or runtime with the C++ engine that lives in the rest of the repo —
+> you do **not** need to understand the engine to work on it. (For how it fits into the whole repo, see
+> the root `AGENTS.md`; you rarely need it here.)
+
+## Project Overview
+
+- **ECS3DLauncher** is the project-management front door for the ECS3D engine: a dark-themed desktop GUI
+  for browsing recent projects, templates, samples, and learning material — the "hub" you'd open before
+  launching the editor.
+- Built with **Avalonia 12** (cross-platform XAML UI) on **.NET 10**, using the **MVVM** pattern via
+  **CommunityToolkit.Mvvm** (`[ObservableProperty]`, `[RelayCommand]`, `ObservableObject`).
+- **Status: UI shell only.** Everything is presentation right now — the project/template/sample lists are
+  hardcoded sample data (see `ProjectsViewModel`, `DesignData`) and commands only drive navigation. There
+  is **no engine backend wired in yet**: no real project loading, no process launching, no persistence.
+- Ships as a single-file `ECS3DLauncher.exe` beside the C++ executables in `bin/`. It is
+  **framework-dependent** (shares the machine's installed .NET 10) and does **not** boot the CLR the way
+  the engine apps do — it is just an ordinary .NET desktop process.
+
+## Layout
+
+All source lives under `source/` (mirrored by the `avares://ECS3DLauncher/source/...` resource authority).
+
+| Path | Responsibility |
+|------|----------------|
+| `source/Program.cs` | Avalonia entry point (`BuildAvaloniaApp`). Minimal — no app logic. |
+| `source/App.axaml{,.cs}` | Application composition: merges `Theme.axaml` + `Icons.axaml` resources and `AppStyles.axaml`; sets the dark `FluentTheme`; creates the single `MainWindow` with its `MainWindowViewModel`. Attaches Avalonia DevTools (F12) in DEBUG only. |
+| `source/Shell/` | The window frame and navigation. `MainWindow.axaml{,.cs}` (frameless window — manual edge-resize/move/maximize in code-behind), `MainWindowViewModel` (sidebar nav + which tab is active + derived title/subtitle), `NavItemViewModel`. |
+| `source/Tabs/` | One folder per library section: `Projects`, `Templates`, `Samples`, `Learn`, `Settings`. Each has a `*View.axaml{,.cs}` + `*ViewModel.cs`. The shell owns navigation; a tab only asks the shell to switch (e.g. Projects → Templates). |
+| `source/Shared/` | Cross-cutting pieces: `Models/` (`Project`, `ProjectTemplate` — plain records), `Resources/` (`Theme.axaml` palette+fonts, `Icons.axaml` geometries), `Styles/AppStyles.axaml` (style selectors), `Controls/` (`EmptyState`), `Converters/` (`IconKeyConverter`), `DesignData.cs`. |
+| `source/Assets/` | Bundled `AvaloniaResource`s: `Fonts/` (Geist, GeistMono) and `scene_render.png`. |
+
+## Build & Run
+
+- **Standalone (the normal way to develop this):** `dotnet run` from this directory, or open the folder in
+  Rider/VS. The SDK uses default `obj/` and `bin/` locations (both git-ignored).
+- **As part of the engine (CMake):** the root build treats this as an `add_executable` target for CLion's
+  sake — it compiles a trivial C stub to `bin/ECS3DLauncher.exe`, then a `POST_BUILD` step overwrites it
+  in place with the real single-file `dotnet publish` output. See `CMakeLists.txt` (heavily commented).
+  Under CMake, `obj/bin` intermediates are redirected into the CMake tree via `Directory.Build.props`
+  (`LauncherObjDir`/`LauncherBinDir`) so the source tree stays clean.
+- **Config split matters:** `BaseIntermediateOutputPath`/`BaseOutputPath` live in `Directory.Build.props`
+  (not the `.csproj`) because they must be set before the SDK imports its common props and be visible to
+  `restore`. Don't move them into the `.csproj`.
+- **Release vs Debug:** CMake always publishes **Release**. Debug-only dev tooling (HotAvalonia XAML
+  hot-reload, `AvaloniaUI.DiagnosticsSupport` DevTools) is gated to `Debug` in the `.csproj` and must
+  never ship. The `AssemblyName` is `ECS3DLauncher` (also the `avares://` authority) — keep it in sync
+  with `Theme.axaml`/`ProjectsViewModel` resource URIs if renamed.
+
+## Conventions
+
+- **MVVM, strictly.** Views are XAML; state and commands live in view models (`ObservableObject` +
+  source-generated `[ObservableProperty]`/`[RelayCommand]`). `AvaloniaUseCompiledBindingsByDefault` is on —
+  give bindings an `x:DataType` so they compile. `Nullable` is enabled.
+- **Navigation is centralized.** `MainWindowViewModel.ActiveNav` (a string key) selects `CurrentTab`; the
+  window's `ContentControl` maps the active view model to its view by type. Tabs never navigate directly —
+  they call back into the shell (see `ProjectsViewModel`'s `openTemplates`).
+- **Theming lives in `Shared/Resources` + `Shared/Styles`.** Colors, brushes, fonts → `Theme.axaml`;
+  icon geometries → `Icons.axaml`; control/style selectors → `AppStyles.axaml`. Don't hardcode colors in
+  views — reference the palette resources. Icons are chosen by string key resolved through
+  `IconKeyConverter` (uses `TryGetResource` so it traverses merged dictionaries).
+- **Design-time preview:** reference `Shared/DesignData` via `d:DataContext` so views render real content
+  in the previewer. `DesignData` is design-only and stripped at runtime.
+- **Frameless window quirks:** `MainWindow` is `WindowDecorations="None"`, so edge-resize, move, and
+  maximize/restore are reimplemented in `MainWindow.axaml.cs`. Keep window-chrome logic there; keep app
+  logic in view models.
+- **Code-loaded brushes:** where a bound brush won't inherit the item `DataContext` (e.g. gradient stops),
+  build the brush in the model instead of XAML — see `Project.GlowBrush` for the pattern and the why.
+
+## AI Agent Guidelines
+
+- Read this file before changing the launcher. You should **not** need the root `AGENTS.md` or any C++
+  engine knowledge for launcher work.
+- This is a **UI shell with placeholder data.** When asked to "load projects" / "open the editor" / etc.,
+  note that no backend exists yet — confirm whether the task is to build real functionality (new service +
+  wiring) or extend the mock UI, rather than assuming a backend is present.
+- Keep the MVVM split clean: no app logic in code-behind, no view construction in view models.
+- Add UI dependencies via `PackageReference` in `ECS3DLauncher.csproj`; keep Debug-only tooling under the
+  `Configuration == Debug` item group so it never ships.
+- Prefer extending existing tabs/resources over introducing parallel navigation or theming systems.
+- Update this document when the launcher's structure or conventions meaningfully change — especially once
+  a real backend is wired in.

--- a/source/libs/protocol/Protocol.h
+++ b/source/libs/protocol/Protocol.h
@@ -20,7 +20,7 @@ inline constexpr int defaultPort = 3000;
 enum class MessageType : uint8_t {
   undefined,
   join,         // client -> server: request the initial Snapshot (carries role + auth at handshake)
-  snapshot,     // server -> client: full project/scene state (ProjectSerializer::serialize())
+  snapshot,     // server -> client: full project/scene state (ProjectPacker::pack())
   stateDelta,   // server -> client: per-tick transform stream, packed binary (replication::packStateDelta)
   inputState,    // client -> server: local input ({ keys, focused }) for the scripts to read
   editComponent, // editor -> server -> all: a single component value edit (replication::buildComponentEdit)


### PR DESCRIPTION
This pull request introduces comprehensive documentation for both the main ECS3D engine and the standalone ECS3D Launcher. It adds two new `AGENTS.md` files: one at the repository root, detailing the architecture, structure, and conventions of the C++ engine and its ecosystem, and another under the launcher, focusing on the C# Avalonia UI project. Additionally, it clarifies a protocol comment regarding scene state serialization.

The most important changes are:

**Documentation: Engine and Launcher Overviews**

* Added a detailed `AGENTS.md` at the repository root, providing a high-level overview of ECS3D's architecture, repository structure, build system, development principles, and application roles. This serves as the primary onboarding and reference document for contributors and AI agents.
* Added a separate `AGENTS.md` under `source/apps/launcher/` specifically for the ECS3D Launcher, outlining its standalone nature, MVVM conventions, project structure, and build process. This ensures clear separation and guidance for launcher development.

**Protocol Clarification**

* Updated the comment for the `snapshot` message type in `Protocol.h` to specify that the server sends the full project/scene state using `ProjectPacker::pack()` (binary wire format), replacing the previous reference to `ProjectSerializer::serialize()` (JSON). This clarifies the serialization path for network replication.