### PR TITLE
Enhance script bindings for object lookup, replication, and Vector3 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 | `source/libs/render/` | `ECS3DRender` — `RenderSystem` (draws models/lights, pick feedback, selection highlight, collider gizmos), `GpuAssetCache` (UUID → `vke` GPU objects), `InputCapture`. Depends on `ECS3DData` + `VulkanEngine`. |
 | `source/libs/editor/` | `ECS3DEditorLib` — ImGui editing UI: `ComponentEditor` (per-type handlers), `ObjectGUIManager` (object tree + inspector), `AssetBrowserPanel`, `SaveUI`, `GuiComponents`. Depends on `ECS3DData` + `ECS3DRender` + `nfd`. |
 | `source/libs/net/` | `ECS3DNet` — `NetServer`/`NetClient`/`MessageQueue`/`ServerProcess` (C++), plus the `Transport/` C# assembly (`ECS3DNetTransport`, TCP + WebSocket backends). |
-| `source/libs/scripting/` | `ECS3DScripting` — `ScriptSystem`/`ScriptEngine` + native `bindings/` (Transform, RigidBody, InputUtils; `InputState`), plus the `ScriptBridge/` C# assembly and example `UserScripts/`. |
+| `source/libs/scripting/` | `ECS3DScripting` — `ScriptSystem`/`ScriptEngine` + native `bindings/` (Transform, RigidBody, InputUtils, World; `InputState`, `BindingContext`), plus the `ScriptBridge/` C# assembly and example `UserScripts/`. |
 | `source/libs/clrHost/` | `ECS3DClrHost` — `ManagedHost` boots CoreCLR and hands out managed statics as native fn ptrs. Owns the CMake helpers (`cmake/ECS3DManaged.cmake`, `FindDotnet.cmake`, `loadCS.cmake`). |
 | `source/apps/` | The executables. `apps/CMakeLists.txt` orders them (server first — client/editor depend on it). |
 | `source/apps/{server,client,editor}/` | The three C++ apps: a thin `main.cpp` (argv parsing) + a `*App` class. |
@@ -89,6 +89,10 @@ rebuilds from it, atomically (a malformed packet leaves the current project inta
 goes as a compact binary **stateDelta** (uuid + local transform per object; `data/Replication.{h,cpp}`).
 Edits flow the other way as typed commands (`editComponent`, `sceneEdit`, `sceneControl`, `loadProject`,
 `addAsset`) that only a connection authorized as `Role::editor` on an `--edit` server may send.
+Runtime structural changes from a *script* (spawn/destroy) take a third path: lightweight
+`objectSpawned` (one packed `Object`) / `objectDestroyed` (a uuid) messages the client splices into/out of
+its scene incrementally — kept off the full-snapshot path so frequent spawning stays cheap. Build/apply
+live in `data/Replication.{h,cpp}`; a late joiner still gets the objects via the normal join snapshot.
 
 **Transport / CLR.** `Protocol.h` defines the format; `NetServer`/`NetClient` own it in C++ and hand
 `ECS3DNetTransport` (C#) opaque `(type byte, payload)` pairs. `ManagedHost` boots CoreCLR and resolves
@@ -97,11 +101,18 @@ thread-safe `MessageQueue` and drained by the app loop. The transport backend (T
 selected by a single field in `Transport.cs`.
 
 **Scripting.** `ScriptSystem` drives `ScriptBridge` (C# gameplay scripts) through `ManagedHost`. Native
-`bindings/` expose Transform/RigidBody/InputUtils to C# via fn-ptr structs. The headless server has no
-GLFW window, so input is networked: clients send `inputState`, the server writes it into the global
-`InputState`, and `InputUtilsBindings` reads it back for scripts. Forces requested from a script are
-buffered on the `RigidBody` data (pending-force queue) and drained by `PhysicsSystem`, keeping
-`scripting` independent of `sim`.
+`bindings/` expose Transform/RigidBody/InputUtils/World to C# via fn-ptr structs; each fn-ptr struct is
+mirrored by a C# `[StructLayout(Sequential)]` struct and registered through `Bridge` (add new fields at
+the **end** of both to keep the layout matched). `BindingContext` is the bridge from the static, C-ABI
+bindings back to the server's live scene: `ScriptSystem` points it at the current `ObjectManager` each
+tick. The headless server has no GLFW window, so input is networked: clients send `inputState`, the
+server writes it into the global `InputState`, and `InputUtilsBindings` reads it back for scripts. Forces
+requested from a script are buffered on the `RigidBody` data (pending-force queue) and drained by
+`PhysicsSystem`, keeping `scripting` independent of `sim`. Two conventions worth inheriting: (1) reaching
+another object's component is a **`tryGet`** (`World.tryGetTransform(uuid, out t)` → false when
+absent/destroyed; never throws in the tick loop) — future component wrappers follow this; (2) a binding
+that mutates scene structure can't touch the net layer, so it **buffers the change on `BindingContext`**
+and the app drains + replicates it after the tick (see the spawn/destroy path in Replication above).
 
 ## Development Principles
 

--- a/source/apps/client/ClientApp.cpp
+++ b/source/apps/client/ClientApp.cpp
@@ -186,6 +186,14 @@ void ClientApp::applyMessage(const net::Message& message) const
       handleEditComponent(message);
       break;
 
+    case net::MessageType::objectSpawned:
+      handleObjectSpawned(message);
+      break;
+
+    case net::MessageType::objectDestroyed:
+      handleObjectDestroyed(message);
+      break;
+
     default: break;
   }
 }
@@ -217,5 +225,23 @@ void ClientApp::handleEditComponent(const net::Message& message) const
   if (const auto scene = m_sceneManager->getCurrentScene())
   {
     replication::applyComponentEdit(*scene->getObjectManager(), message);
+  }
+}
+
+void ClientApp::handleObjectSpawned(const net::Message& message) const
+{
+  // A script spawned an object at runtime; splice the packed object into the replicated scene.
+  if (const auto scene = m_sceneManager->getCurrentScene())
+  {
+    replication::applyObjectSpawned(*scene->getObjectManager(), message);
+  }
+}
+
+void ClientApp::handleObjectDestroyed(const net::Message& message) const
+{
+  // A script destroyed an object at runtime; drop it from the replicated scene.
+  if (const auto scene = m_sceneManager->getCurrentScene())
+  {
+    replication::applyObjectDestroyed(*scene->getObjectManager(), message);
   }
 }

--- a/source/apps/client/ClientApp.h
+++ b/source/apps/client/ClientApp.h
@@ -79,6 +79,10 @@ private:
   void handleStateDelta(const net::Message& message) const;
 
   void handleEditComponent(const net::Message& message) const;
+
+  void handleObjectSpawned(const net::Message& message) const;
+
+  void handleObjectDestroyed(const net::Message& message) const;
 };
 
 

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -349,6 +349,14 @@ void EditorApp::applyMessage(const net::Message& message)
       handleEditComponent(message);
       break;
 
+    case net::MessageType::objectSpawned:
+      handleObjectSpawned(message);
+      break;
+
+    case net::MessageType::objectDestroyed:
+      handleObjectDestroyed(message);
+      break;
+
     case net::MessageType::editStatus:
       handleEditStatus(message);
       break;
@@ -386,6 +394,24 @@ void EditorApp::handleEditComponent(const net::Message& message) const
   if (const auto scene = m_sceneManager->getCurrentScene())
   {
     replication::applyComponentEdit(*scene->getObjectManager(), message);
+  }
+}
+
+void EditorApp::handleObjectSpawned(const net::Message& message) const
+{
+  // A script spawned an object at runtime; splice the packed object into the replicated scene.
+  if (const auto scene = m_sceneManager->getCurrentScene())
+  {
+    replication::applyObjectSpawned(*scene->getObjectManager(), message);
+  }
+}
+
+void EditorApp::handleObjectDestroyed(const net::Message& message) const
+{
+  // A script destroyed an object at runtime; drop it from the replicated scene.
+  if (const auto scene = m_sceneManager->getCurrentScene())
+  {
+    replication::applyObjectDestroyed(*scene->getObjectManager(), message);
   }
 }
 

--- a/source/apps/editor/EditorApp.h
+++ b/source/apps/editor/EditorApp.h
@@ -120,6 +120,10 @@ private:
 
   void handleEditComponent(const net::Message& message) const;
 
+  void handleObjectSpawned(const net::Message& message) const;
+
+  void handleObjectDestroyed(const net::Message& message) const;
+
   void handleEditStatus(const net::Message& message);
 
   void handleSceneStatus(const net::Message& message);

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -9,11 +9,13 @@
 #include <scenes/SceneManager.h>
 #include <scenes/SceneAsset.h>
 #include <objects/ObjectManager.h>
+#include <objects/Object.h>
 #include <objects/components/Component.h>
 #include <PhysicsSystem.h>
 #include <CollisionSystem.h>
 #include <ScriptSystem.h>
 #include <bindings/InputState.h>
+#include <bindings/BindingContext.h>
 #include <NetServer.h>
 #include <ManagedHost.h>
 #include <nlohmann/json.hpp>
@@ -144,6 +146,10 @@ void ServerApp::run()
     // this guard the unbounded loop would flood every client with deltas and stall their drain loops.
     if (ticked)
     {
+      // Replicate any runtime spawn/destroy the tick's scripts requested before the delta, so a client
+      // has the object (or has dropped it) by the time the delta for this tick references it.
+      broadcastStructuralChanges();
+
       broadcastStateDelta();
     }
 
@@ -564,6 +570,32 @@ void ServerApp::broadcastStateDelta() const
   net::Message message(net::MessageType::stateDelta);
   replication::packStateDelta(message, *scene->getObjectManager());
   m_netServer->broadcast(message);
+}
+
+void ServerApp::broadcastStructuralChanges() const
+{
+  // The spawn/destroy bindings buffered what the scripts did on BindingContext (scripting can't reach the
+  // net layer). Broadcast spawns before destroys, then remove the marked objects from the authoritative
+  // scene. A spawned object is still live here, so its packed blob carries current transform/components.
+  const auto spawned = BindingContext::takeSpawned();
+  for (const auto& object : spawned)
+  {
+    m_netServer->broadcast(replication::buildObjectSpawned(*object));
+  }
+
+  const auto destroyed = BindingContext::takeDestroyed();
+  for (const auto& uuid : destroyed)
+  {
+    m_netServer->broadcast(replication::buildObjectDestroyed(uuid));
+  }
+
+  if (!destroyed.empty())
+  {
+    if (const auto scene = m_sceneManager->getCurrentScene())
+    {
+      scene->getObjectManager()->deleteObjectsMarkedForDeletion();
+    }
+  }
 }
 
 void ServerApp::logMessage(const std::string& level, const std::string& message)

--- a/source/apps/server/ServerApp.h
+++ b/source/apps/server/ServerApp.h
@@ -97,6 +97,11 @@ private:
   void broadcastSceneStatus() const;
 
   void broadcastStateDelta() const;
+
+  // Drain the spawn/destroy a script requested this tick (buffered on BindingContext): broadcast an
+  // objectSpawned/objectDestroyed per change, then actually delete the marked objects. Runs after the
+  // tick's scripts, before the state delta.
+  void broadcastStructuralChanges() const;
 };
 
 

--- a/source/libs/data/Replication.cpp
+++ b/source/libs/data/Replication.cpp
@@ -411,6 +411,51 @@ void applySceneEdit(ObjectManager& objectManager, const nlohmann::json& edit)
   }
 }
 
+net::Message buildObjectSpawned(const Object& object)
+{
+  net::Message message(net::MessageType::objectSpawned);
+  object.pack(message);
+  return message;
+}
+
+net::Message buildObjectDestroyed(const uuids::uuid& objectUUID)
+{
+  net::Message message(net::MessageType::objectDestroyed);
+  message.writeString(uuids::to_string(objectUUID));
+  return message;
+}
+
+void applyObjectSpawned(ObjectManager& objectManager, const net::Message& message)
+{
+  // Symmetric with buildObjectSpawned: reconstruct one root object exactly as ObjectManager::unpack does
+  // per object (fresh Object, registered so it has a manager, then unpacked from the packed blob).
+  net::MessageReader reader(message);
+
+  auto object = std::make_shared<Object>();
+  objectManager.addObject(object);
+  object->unpack(reader);
+}
+
+void applyObjectDestroyed(ObjectManager& objectManager, const net::Message& message)
+{
+  net::MessageReader reader(message);
+
+  const auto parsed = uuids::uuid::from_string(reader.readString());
+  if (!parsed.has_value())
+  {
+    return;
+  }
+
+  const auto object = objectManager.getObjectByUUID(parsed.value());
+  if (!object)
+  {
+    return;
+  }
+
+  objectManager.removeObject(object);
+  objectManager.deleteObjectsMarkedForDeletion();
+}
+
 void applyAddAsset(AssetRegistry& assetRegistry,
                    SceneManager& sceneManager,
                    const std::shared_ptr<ComponentRegistry>& componentRegistry,

--- a/source/libs/data/Replication.h
+++ b/source/libs/data/Replication.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <uuid.h>
 
+class Object;
 class ObjectManager;
 class Component;
 class AssetRegistry;
@@ -61,6 +62,18 @@ void applyComponentEdit(const ObjectManager& objectManager, const net::Message& 
                                             const std::string& className);
 
 void applySceneEdit(ObjectManager& objectManager, const nlohmann::json& edit);
+
+// Runtime spawn/destroy replication. Unlike the editor's structural edits (which re-snapshot), a script
+// spawning or destroying an object at runtime replicates incrementally: the server broadcasts one packed
+// object (spawn) or a uuid (destroy), and each view splices it into / out of its replicated scene. Keeps
+// frequent runtime spawning off the full-snapshot path.
+[[nodiscard]] net::Message buildObjectSpawned(const Object& object);
+
+[[nodiscard]] net::Message buildObjectDestroyed(const uuids::uuid& objectUUID);
+
+void applyObjectSpawned(ObjectManager& objectManager, const net::Message& message);
+
+void applyObjectDestroyed(ObjectManager& objectManager, const net::Message& message);
 
 // Register an imported/created asset ({ assetType, uuid, path|name, [className] }). Shared by the
 // server (authoritative) and the editor (instant local feedback). Models/textures/scripts go into the

--- a/source/libs/editor/components/ScriptEditor.cpp
+++ b/source/libs/editor/components/ScriptEditor.cpp
@@ -62,6 +62,20 @@ void registerScriptEditor(ComponentEditor& componentEditor)
             edited = true;
           }
         }
+        else if (type == "vector3")
+        {
+          const auto& value = field.at("value");
+          float vec[3] = {
+            value.is_array() && value.size() == 3 ? value.at(0).get<float>() : 0.0f,
+            value.is_array() && value.size() == 3 ? value.at(1).get<float>() : 0.0f,
+            value.is_array() && value.size() == 3 ? value.at(2).get<float>() : 0.0f
+          };
+          if (ImGui::DragFloat3(name.c_str(), vec, 0.1f))
+          {
+            field["value"] = { vec[0], vec[1], vec[2] };
+            edited = true;
+          }
+        }
         else
         {
           ImGui::LabelText(name.c_str(), "%s", field.at("value").is_string()

--- a/source/libs/protocol/Protocol.h
+++ b/source/libs/protocol/Protocol.h
@@ -29,7 +29,9 @@ enum class MessageType : uint8_t {
   loadProject,   // editor -> server: replace the project with this serialized blob; server re-snapshots
   addAsset,      // editor -> server: register a new asset (model/texture/script/scene); server re-snapshots
   editStatus,    // server -> client: whether this server accepts edits ({ editable: bool }); sent on join
-  sceneStatus    // server -> client: current scene lifecycle state ({ status: "running"|"paused"|"stopped" })
+  sceneStatus,   // server -> client: current scene lifecycle state ({ status: "running"|"paused"|"stopped" })
+  objectSpawned, // server -> client: one object created at runtime (Object::pack); spliced into the scene
+  objectDestroyed // server -> client: uuid of an object removed at runtime; the client drops it from the scene
   // editComponent/sceneEdit/sceneControl/loadProject/addAsset are the editor's mutation path; the server
   // only honors them from a connection it authorized as Role::editor at the transport handshake (which
   // carries role + token out of band, ahead of any message here), and only on an edit-mode server. An

--- a/source/libs/scripting/CMakeLists.txt
+++ b/source/libs/scripting/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(${PROJECT_NAME}
   bindings/RigidBodyBindings.h
   bindings/InputUtilsBindings.cpp
   bindings/InputUtilsBindings.h
+  bindings/WorldBindings.cpp
+  bindings/WorldBindings.h
   bindings/InputState.cpp
   bindings/InputState.h
 )

--- a/source/libs/scripting/ScriptBridge/ScriptBase.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBase.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ScriptBridge;
 
 public abstract class ScriptBase
@@ -13,6 +15,17 @@ public abstract class ScriptBase
         rigidBody = new RigidBody(EntityId);
         transform = new Transform(EntityId);
     }
+
+    // Reach another script by type. Returns null if the object has no script of type T (or no such
+    // object). The no-argument overloads target this script's own object, for sibling-script access.
+    protected T? getScript<T>(string uuid) where T : ScriptBase => Bridge.FindScript<T>(uuid);
+
+    protected T? getScript<T>() where T : ScriptBase => Bridge.FindScript<T>(EntityId);
+
+    // All scripts on an object, for the untyped case (e.g. broadcasting an intent to whatever is there).
+    protected IReadOnlyList<ScriptBase> getScripts(string uuid) => Bridge.FindScripts(uuid);
+
+    protected IReadOnlyList<ScriptBase> getScripts() => Bridge.FindScripts(EntityId);
 
     public virtual void start() {}
     public virtual void fixedUpdate(float dt) {}

--- a/source/libs/scripting/ScriptBridge/ScriptBridge.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBridge.cs
@@ -19,6 +19,15 @@ public static class Bridge
     private static readonly Dictionary<string, ScriptBase> _instances = new();
     private static string Key(string uuid, string className) => $"{uuid}_{className}";
 
+    // Script-to-script access. An object can carry several scripts (one per class), so a script is
+    // addressed by type (FindScript<T>) or enumerated for the untyped case (FindScripts). Purely a view
+    // over the live instances — ScriptBase exposes these as getScript<T>/getScripts to user scripts.
+    internal static T? FindScript<T>(string uuid) where T : ScriptBase =>
+        _instances.Values.OfType<T>().FirstOrDefault(s => s.EntityId == uuid);
+
+    internal static IReadOnlyList<ScriptBase> FindScripts(string uuid) =>
+        _instances.Values.Where(s => s.EntityId == uuid).ToList();
+
     private static string ReadFileSafe(string path)
     {
         using var fs = new FileStream(

--- a/source/libs/scripting/ScriptBridge/ScriptBridge.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBridge.cs
@@ -253,6 +253,12 @@ public static class Bridge
     }
 
     [UnmanagedCallersOnly]
+    public static unsafe void registerWorldBindings(WorldBindings bindings)
+    {
+        NativeBindings.World = bindings;
+    }
+
+    [UnmanagedCallersOnly]
     public static void attachScript(IntPtr uuidPtr, IntPtr classNamePtr)
     {
         var uuid = Marshal.PtrToStringUTF8(uuidPtr)!;

--- a/source/libs/scripting/ScriptBridge/ScriptBridge.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBridge.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
@@ -174,6 +175,16 @@ public static class Bridge
     public static byte getFieldBool(IntPtr uuidPtr, IntPtr classNamePtr, IntPtr fieldNamePtr)
         => (byte)(((bool)(GetField(uuidPtr, classNamePtr, fieldNamePtr) ?? false)) ? 1 : 0);
 
+    [UnmanagedCallersOnly]
+    public static unsafe void getFieldVector3(IntPtr uuidPtr, IntPtr classNamePtr, IntPtr fieldNamePtr,
+                                              float* x, float* y, float* z)
+    {
+        var v = (Vector3)(GetField(uuidPtr, classNamePtr, fieldNamePtr) ?? Vector3.Zero);
+        *x = v.X;
+        *y = v.Y;
+        *z = v.Z;
+    }
+
     private static object? GetField(IntPtr uuidPtr, IntPtr classNamePtr, IntPtr fieldNamePtr)
     {
         var key = Key(Marshal.PtrToStringUTF8(uuidPtr)!, Marshal.PtrToStringUTF8(classNamePtr)!);
@@ -202,6 +213,11 @@ public static class Bridge
     public static void setFieldBool(IntPtr uuidPtr, IntPtr classNamePtr, IntPtr fieldNamePtr, byte value)
         => SetField(uuidPtr, classNamePtr, fieldNamePtr, value != 0);
 
+    [UnmanagedCallersOnly]
+    public static void setFieldVector3(IntPtr uuidPtr, IntPtr classNamePtr, IntPtr fieldNamePtr,
+                                       float x, float y, float z)
+        => SetField(uuidPtr, classNamePtr, fieldNamePtr, new Vector3(x, y, z));
+
     private static void SetField(IntPtr uuidPtr, IntPtr classNamePtr, IntPtr fieldNamePtr, object value)
     {
         var key = Key(Marshal.PtrToStringUTF8(uuidPtr)!, Marshal.PtrToStringUTF8(classNamePtr)!);
@@ -215,7 +231,15 @@ public static class Bridge
             .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
             .FirstOrDefault(f => f.Name == fieldName && f.GetCustomAttribute<ExposeToEditorAttribute>() != null);
 
-        field?.SetValue(instance, Convert.ChangeType(value, field.FieldType));
+        if (field == null)
+        {
+            return;
+        }
+
+        // Convert.ChangeType only handles IConvertible (float/int/bool); a struct like Vector3 arrives as
+        // the field's own type already, so assign it directly.
+        var converted = field.FieldType.IsInstanceOfType(value) ? value : Convert.ChangeType(value, field.FieldType);
+        field.SetValue(instance, converted);
     }
 
     private static string? MapTypeName(Type t)
@@ -238,6 +262,11 @@ public static class Bridge
         if (t == typeof(string))
         {
             return "string";
+        }
+
+        if (t == typeof(Vector3))
+        {
+            return "vector3";
         }
 
         return null;

--- a/source/libs/scripting/ScriptBridge/components/NativeBindings.cs
+++ b/source/libs/scripting/ScriptBridge/components/NativeBindings.cs
@@ -7,4 +7,6 @@ internal static unsafe class NativeBindings
     internal static RigidBodyBindings RigidBody;
 
     internal static TransformBindings Transform;
+
+    internal static WorldBindings World;
 }

--- a/source/libs/scripting/ScriptBridge/components/RigidBody.cs
+++ b/source/libs/scripting/ScriptBridge/components/RigidBody.cs
@@ -10,6 +10,7 @@ public unsafe struct RigidBodyBindings
     public delegate* unmanaged<IntPtr, float, float, float, float, float, float, void> applyForce;
     public delegate* unmanaged<IntPtr, float, float, float, void> setVelocity;
     public delegate* unmanaged<IntPtr, bool> isFalling;
+    public delegate* unmanaged<IntPtr, bool> has;
 }
 
 public unsafe class RigidBody

--- a/source/libs/scripting/ScriptBridge/components/Transform.cs
+++ b/source/libs/scripting/ScriptBridge/components/Transform.cs
@@ -15,6 +15,7 @@ public unsafe struct TransformBindings
     public delegate* unmanaged<IntPtr, float, float, float, void> move;
     public delegate* unmanaged<IntPtr, void> start;
     public delegate* unmanaged<IntPtr, void> stop;
+    public delegate* unmanaged<IntPtr, bool> has;
 }
 
 public unsafe class Transform

--- a/source/libs/scripting/ScriptBridge/components/World.cs
+++ b/source/libs/scripting/ScriptBridge/components/World.cs
@@ -67,4 +67,46 @@ public static unsafe class World
 
         return result.Split(',');
     }
+
+    // Acquire another object's Transform. Returns false (and a null wrapper) when the object doesn't
+    // exist or has no Transform, so scripts branch instead of operating on a dead handle. This is the
+    // project-wide convention for reaching another object's components; every component wrapper follows
+    // it. A handle that outlives its component (e.g. the object is destroyed later this tick) degrades
+    // to safe no-op calls.
+    public static bool tryGetTransform(string uuid, out Transform transform)
+    {
+        if (has(NativeBindings.Transform.has, uuid))
+        {
+            transform = new Transform(uuid);
+            return true;
+        }
+
+        transform = null!;
+        return false;
+    }
+
+    public static bool tryGetRigidBody(string uuid, out RigidBody rigidBody)
+    {
+        if (has(NativeBindings.RigidBody.has, uuid))
+        {
+            rigidBody = new RigidBody(uuid);
+            return true;
+        }
+
+        rigidBody = null!;
+        return false;
+    }
+
+    private static bool has(delegate* unmanaged<IntPtr, bool> nativeHas, string uuid)
+    {
+        var uuidPtr = Marshal.StringToCoTaskMemUTF8(uuid);
+        try
+        {
+            return nativeHas(uuidPtr);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(uuidPtr);
+        }
+    }
 }

--- a/source/libs/scripting/ScriptBridge/components/World.cs
+++ b/source/libs/scripting/ScriptBridge/components/World.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ScriptBridge;
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct WorldBindings
+{
+    public delegate* unmanaged<IntPtr, IntPtr> findObjectByName;
+    public delegate* unmanaged<IntPtr, IntPtr> getObjectName;
+    public delegate* unmanaged<IntPtr, bool> objectExists;
+    public delegate* unmanaged<IntPtr> getAllObjectUuids;
+}
+
+// World queries available to any user script: find objects, read names, and enumerate the scene.
+// Returned uuids can be handed to a Transform/RigidBody wrapper to read/write another object's state.
+public static unsafe class World
+{
+    public static string findObjectByName(string name)
+    {
+        var namePtr = Marshal.StringToCoTaskMemUTF8(name);
+        try
+        {
+            // The native side returns a pointer into its own thread-local buffer; marshal it out
+            // immediately and do not free it (argument ownership is ours, return ownership is native's).
+            return Marshal.PtrToStringUTF8(NativeBindings.World.findObjectByName(namePtr)) ?? "";
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(namePtr);
+        }
+    }
+
+    public static string getObjectName(string uuid)
+    {
+        var uuidPtr = Marshal.StringToCoTaskMemUTF8(uuid);
+        try
+        {
+            return Marshal.PtrToStringUTF8(NativeBindings.World.getObjectName(uuidPtr)) ?? "";
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(uuidPtr);
+        }
+    }
+
+    public static bool objectExists(string uuid)
+    {
+        var uuidPtr = Marshal.StringToCoTaskMemUTF8(uuid);
+        try
+        {
+            return NativeBindings.World.objectExists(uuidPtr);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(uuidPtr);
+        }
+    }
+
+    public static string[] getAllObjects()
+    {
+        var result = Marshal.PtrToStringUTF8(NativeBindings.World.getAllObjectUuids());
+        if (string.IsNullOrEmpty(result))
+        {
+            return Array.Empty<string>();
+        }
+
+        return result.Split(',');
+    }
+}

--- a/source/libs/scripting/ScriptBridge/components/World.cs
+++ b/source/libs/scripting/ScriptBridge/components/World.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace ScriptBridge;
@@ -10,6 +11,8 @@ public unsafe struct WorldBindings
     public delegate* unmanaged<IntPtr, IntPtr> getObjectName;
     public delegate* unmanaged<IntPtr, bool> objectExists;
     public delegate* unmanaged<IntPtr> getAllObjectUuids;
+    public delegate* unmanaged<IntPtr, float, float, float, IntPtr> spawnObject;
+    public delegate* unmanaged<IntPtr, void> destroyObject;
 }
 
 // World queries available to any user script: find objects, read names, and enumerate the scene.
@@ -103,6 +106,40 @@ public static unsafe class World
         try
         {
             return nativeHas(uuidPtr);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(uuidPtr);
+        }
+    }
+
+    // Spawn a minimal object (a Transform at the given position) and return its uuid. The object appears
+    // on connected clients after the current tick. Full prefab spawn (with model/scripts) arrives in
+    // Phase 5; for now, hand the returned uuid to tryGetTransform to drive it.
+    public static string spawn(string name, float x, float y, float z)
+    {
+        var namePtr = Marshal.StringToCoTaskMemUTF8(name);
+        try
+        {
+            return Marshal.PtrToStringUTF8(NativeBindings.World.spawnObject(namePtr, x, y, z)) ?? "";
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(namePtr);
+        }
+    }
+
+    public static string spawn(string name, Vector3 position) => spawn(name, position.X, position.Y, position.Z);
+
+    // Destroy an object at runtime. Safe if the uuid is unknown/already gone (no-op). The removal takes
+    // effect at the end of the tick (mark-for-deletion), so a wrapper held for this uuid degrades to
+    // safe no-op calls afterward.
+    public static void destroy(string uuid)
+    {
+        var uuidPtr = Marshal.StringToCoTaskMemUTF8(uuid);
+        try
+        {
+            NativeBindings.World.destroyObject(uuidPtr);
         }
         finally
         {

--- a/source/libs/scripting/ScriptEngine.cpp
+++ b/source/libs/scripting/ScriptEngine.cpp
@@ -53,10 +53,12 @@ void ScriptEngine::init(const std::string& bridgeDir,
   m_getFieldFloat = reinterpret_cast<GetFieldFloatFn>(resolve("getFieldFloat"));
   m_getFieldInt = reinterpret_cast<GetFieldIntFn>(resolve("getFieldInt"));
   m_getFieldBool = reinterpret_cast<GetFieldBoolFn>(resolve("getFieldBool"));
+  m_getFieldVector3 = reinterpret_cast<GetFieldVector3Fn>(resolve("getFieldVector3"));
 
   m_setFieldFloat = reinterpret_cast<SetFieldFloatFn>(resolve("setFieldFloat"));
   m_setFieldInt = reinterpret_cast<SetFieldIntFn>(resolve("setFieldInt"));
   m_setFieldBool = reinterpret_cast<SetFieldBoolFn>(resolve("setFieldBool"));
+  m_setFieldVector3 = reinterpret_cast<SetFieldVector3Fn>(resolve("setFieldVector3"));
 
   registerBindings(assemblyPath, kBridgeType);
 
@@ -203,6 +205,17 @@ bool ScriptEngine::getFieldBool(const char* uuid,
   return m_getFieldBool ? m_getFieldBool(uuid, className, fieldName) : false;
 }
 
+void ScriptEngine::getFieldVector3(const char* uuid,
+                                   const char* className,
+                                   const char* fieldName,
+                                   float& x, float& y, float& z) const
+{
+  if (m_getFieldVector3)
+  {
+    m_getFieldVector3(uuid, className, fieldName, &x, &y, &z);
+  }
+}
+
 void ScriptEngine::setFieldFloat(const char* uuid,
                                  const char* className,
                                  const char* fieldName,
@@ -233,5 +246,16 @@ void ScriptEngine::setFieldBool(const char* uuid,
   if (m_setFieldBool)
   {
     m_setFieldBool(uuid, className, fieldName, value);
+  }
+}
+
+void ScriptEngine::setFieldVector3(const char* uuid,
+                                   const char* className,
+                                   const char* fieldName,
+                                   const float x, const float y, const float z) const
+{
+  if (m_setFieldVector3)
+  {
+    m_setFieldVector3(uuid, className, fieldName, x, y, z);
   }
 }

--- a/source/libs/scripting/ScriptEngine.cpp
+++ b/source/libs/scripting/ScriptEngine.cpp
@@ -2,6 +2,7 @@
 #include "bindings/TransformBindings.h"
 #include "bindings/RigidBodyBindings.h"
 #include "bindings/InputUtilsBindings.h"
+#include "bindings/WorldBindings.h"
 #include <ManagedHost.h>
 #include <filesystem>
 #include <iostream>
@@ -79,6 +80,11 @@ void ScriptEngine::registerBindings(const std::string& assemblyPath,
   const auto registerRigidBody =
     reinterpret_cast<RegisterRigidBodyFn>(m_host->getDelegate(assemblyPath, typeName, "registerRigidBodyBindings"));
   registerRigidBody(RigidBodyBindingsProvider::getBindings());
+
+  using RegisterWorldFn = void(*)(WorldBindings);
+  const auto registerWorld =
+    reinterpret_cast<RegisterWorldFn>(m_host->getDelegate(assemblyPath, typeName, "registerWorldBindings"));
+  registerWorld(WorldBindingsProvider::getBindings());
 
   // InputUtils reads the networked InputState (ServerApp writes it from the client's inputState
   // messages), since the headless server has no GLFW window of its own.

--- a/source/libs/scripting/ScriptEngine.h
+++ b/source/libs/scripting/ScriptEngine.h
@@ -54,6 +54,11 @@ public:
                                   const char* className,
                                   const char* fieldName) const;
 
+  void getFieldVector3(const char* uuid,
+                       const char* className,
+                       const char* fieldName,
+                       float& x, float& y, float& z) const;
+
   void setFieldFloat(const char* uuid,
                      const char* className,
                      const char* fieldName,
@@ -68,6 +73,11 @@ public:
                     const char* className,
                     const char* fieldName,
                     bool value) const;
+
+  void setFieldVector3(const char* uuid,
+                       const char* className,
+                       const char* fieldName,
+                       float x, float y, float z) const;
 
   [[nodiscard]] bool isInitialized() const { return m_initialized; }
 
@@ -87,10 +97,12 @@ private:
   using GetFieldFloatFn = float(*)(const char*, const char*, const char*);
   using GetFieldIntFn = int(*)(const char*, const char*, const char*);
   using GetFieldBoolFn = bool(*)(const char*, const char*, const char*);
+  using GetFieldVector3Fn = void(*)(const char*, const char*, const char*, float*, float*, float*);
 
   using SetFieldFloatFn = void(*)(const char*, const char*, const char*, float);
   using SetFieldIntFn = void(*)(const char*, const char*, const char*, int);
   using SetFieldBoolFn = void(*)(const char*, const char*, const char*, bool);
+  using SetFieldVector3Fn = void(*)(const char*, const char*, const char*, float, float, float);
 
   std::shared_ptr<ManagedHost> m_host;
   bool m_initialized = false;
@@ -109,10 +121,12 @@ private:
   GetFieldFloatFn m_getFieldFloat = nullptr;
   GetFieldIntFn m_getFieldInt = nullptr;
   GetFieldBoolFn m_getFieldBool = nullptr;
+  GetFieldVector3Fn m_getFieldVector3 = nullptr;
 
   SetFieldFloatFn m_setFieldFloat = nullptr;
   SetFieldIntFn m_setFieldInt = nullptr;
   SetFieldBoolFn m_setFieldBool = nullptr;
+  SetFieldVector3Fn m_setFieldVector3 = nullptr;
 
   void registerBindings(const std::string& assemblyPath,
                         const std::string& typeName) const;

--- a/source/libs/scripting/ScriptSystem.cpp
+++ b/source/libs/scripting/ScriptSystem.cpp
@@ -333,6 +333,16 @@ void ScriptSystem::writeFieldsToInstance(const uuids::uuid& uuid,
     {
       m_engine->setFieldBool(uuidStr.c_str(), className.c_str(), fieldName, field.at("value").get<bool>());
     }
+    else if (type == "vector3")
+    {
+      // Stored as a [x, y, z] JSON array (see readFieldsFromInstance / ScriptEditor).
+      const auto& value = field.at("value");
+      if (value.is_array() && value.size() == 3)
+      {
+        m_engine->setFieldVector3(uuidStr.c_str(), className.c_str(), fieldName,
+          value.at(0).get<float>(), value.at(1).get<float>(), value.at(2).get<float>());
+      }
+    }
   }
 }
 
@@ -370,6 +380,12 @@ nlohmann::json ScriptSystem::readFieldsFromInstance(const uuids::uuid& uuid,
     else if (field.type == "bool")
     {
       entry["value"] = m_engine->getFieldBool(uuidStr.c_str(), className.c_str(), fieldName);
+    }
+    else if (field.type == "vector3")
+    {
+      float x = 0.0f, y = 0.0f, z = 0.0f;
+      m_engine->getFieldVector3(uuidStr.c_str(), className.c_str(), fieldName, x, y, z);
+      entry["value"] = { x, y, z };
     }
 
     fields.push_back(std::move(entry));

--- a/source/libs/scripting/bindings/BindingContext.cpp
+++ b/source/libs/scripting/bindings/BindingContext.cpp
@@ -1,6 +1,9 @@
 #include "BindingContext.h"
+#include <utility>
 
 ObjectManager* BindingContext::s_objectManager = nullptr;
+std::vector<std::shared_ptr<Object>> BindingContext::s_spawned;
+std::vector<uuids::uuid> BindingContext::s_destroyed;
 
 void BindingContext::setObjectManager(ObjectManager* objectManager)
 {
@@ -10,4 +13,24 @@ void BindingContext::setObjectManager(ObjectManager* objectManager)
 ObjectManager* BindingContext::getObjectManager()
 {
   return s_objectManager;
+}
+
+void BindingContext::recordSpawn(const std::shared_ptr<Object>& object)
+{
+  s_spawned.push_back(object);
+}
+
+void BindingContext::recordDestroy(const uuids::uuid& objectUUID)
+{
+  s_destroyed.push_back(objectUUID);
+}
+
+std::vector<std::shared_ptr<Object>> BindingContext::takeSpawned()
+{
+  return std::exchange(s_spawned, {});
+}
+
+std::vector<uuids::uuid> BindingContext::takeDestroyed()
+{
+  return std::exchange(s_destroyed, {});
 }

--- a/source/libs/scripting/bindings/BindingContext.h
+++ b/source/libs/scripting/bindings/BindingContext.h
@@ -1,18 +1,39 @@
 #ifndef BINDINGCONTEXT_H
 #define BINDINGCONTEXT_H
 
+#include <memory>
+#include <vector>
+#include <uuid.h>
+
+class Object;
 class ObjectManager;
 
 // ScriptSystem points this at the server's current ObjectManager each tick so the (static, C-ABI)
 // bindings can resolve a uuid to its object.
+//
+// Runtime spawn/destroy from a script can't broadcast directly (the bindings know nothing about the net
+// layer), so the spawn/destroy bindings record what happened here; ServerApp drains these after the tick
+// and replicates them (objectSpawned/objectDestroyed) — keeping scripting independent of net/protocol.
 class BindingContext {
 public:
   static void setObjectManager(ObjectManager* objectManager);
 
   [[nodiscard]] static ObjectManager* getObjectManager();
 
+  static void recordSpawn(const std::shared_ptr<Object>& object);
+
+  static void recordDestroy(const uuids::uuid& objectUUID);
+
+  // Return the objects spawned / uuids destroyed since the last call, clearing the buffers.
+  [[nodiscard]] static std::vector<std::shared_ptr<Object>> takeSpawned();
+
+  [[nodiscard]] static std::vector<uuids::uuid> takeDestroyed();
+
 private:
   static ObjectManager* s_objectManager;
+
+  static std::vector<std::shared_ptr<Object>> s_spawned;
+  static std::vector<uuids::uuid> s_destroyed;
 };
 
 

--- a/source/libs/scripting/bindings/RigidBodyBindings.cpp
+++ b/source/libs/scripting/bindings/RigidBodyBindings.cpp
@@ -37,7 +37,8 @@ RigidBodyBindings RigidBodyBindingsProvider::getBindings()
   return RigidBodyBindings {
     .applyForce = &bindApplyForce,
     .setVelocity = &bindSetVelocity,
-    .isFalling = &bindIsFalling
+    .isFalling = &bindIsFalling,
+    .has = &bindHas
   };
 }
 
@@ -74,4 +75,9 @@ bool RigidBodyBindingsProvider::bindIsFalling(const char* uuid)
   }
 
   return rigidBody->isFalling();
+}
+
+bool RigidBodyBindingsProvider::bindHas(const char* uuid)
+{
+  return find(uuid) != nullptr;
 }

--- a/source/libs/scripting/bindings/RigidBodyBindings.h
+++ b/source/libs/scripting/bindings/RigidBodyBindings.h
@@ -6,6 +6,7 @@ struct RigidBodyBindings
   void(*applyForce)(const char* uuid, float x, float y, float z, float px, float py, float pz);
   void(*setVelocity)(const char* uuid, float x, float y, float z);
   bool(*isFalling)(const char* uuid);
+  bool(*has)(const char* uuid);
 };
 
 class RigidBodyBindingsProvider {
@@ -19,6 +20,9 @@ private:
   static void bindSetVelocity(const char* uuid, float x, float y, float z);
 
   static bool bindIsFalling(const char* uuid);
+
+  // Whether the object identified by uuid currently has a RigidBody (backs World.tryGetRigidBody).
+  static bool bindHas(const char* uuid);
 };
 
 

--- a/source/libs/scripting/bindings/TransformBindings.cpp
+++ b/source/libs/scripting/bindings/TransformBindings.cpp
@@ -42,7 +42,8 @@ TransformBindings TransformBindingsProvider::getBindings()
     .setRotation = &bindSetRotation,
     .move = &bindMove,
     .start = &bindStart,
-    .stop = &bindStop
+    .stop = &bindStop,
+    .has = &bindHas
   };
 }
 
@@ -141,4 +142,9 @@ void TransformBindingsProvider::bindStop(const char* uuid)
   }
 
   transform->stop();
+}
+
+bool TransformBindingsProvider::bindHas(const char* uuid)
+{
+  return find(uuid) != nullptr;
 }

--- a/source/libs/scripting/bindings/TransformBindings.h
+++ b/source/libs/scripting/bindings/TransformBindings.h
@@ -11,6 +11,7 @@ struct TransformBindings
   void(*move)(const char* uuid, float x, float y, float z);
   void(*start)(const char* uuid);
   void(*stop)(const char* uuid);
+  bool(*has)(const char* uuid);
 };
 
 class TransformBindingsProvider {
@@ -30,6 +31,9 @@ private:
 
   static void bindStart(const char* uuid);
   static void bindStop(const char* uuid);
+
+  // Whether the object identified by uuid currently has a Transform (backs World.tryGetTransform).
+  static bool bindHas(const char* uuid);
 };
 
 

--- a/source/libs/scripting/bindings/WorldBindings.cpp
+++ b/source/libs/scripting/bindings/WorldBindings.cpp
@@ -2,6 +2,10 @@
 #include "BindingContext.h"
 #include <objects/Object.h>
 #include <objects/ObjectManager.h>
+#include <objects/components/Component.h>
+#include <objects/components/Transform.h>
+#include <glm/vec3.hpp>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -24,7 +28,9 @@ WorldBindings WorldBindingsProvider::getBindings()
     .findObjectByName = &bindFindObjectByName,
     .getObjectName = &bindGetObjectName,
     .objectExists = &bindObjectExists,
-    .getAllObjectUuids = &bindGetAllObjectUuids
+    .getAllObjectUuids = &bindGetAllObjectUuids,
+    .spawnObject = &bindSpawnObject,
+    .destroyObject = &bindDestroyObject
   };
 }
 
@@ -108,4 +114,57 @@ const char* WorldBindingsProvider::bindGetAllObjectUuids()
   }
 
   return store(result);
+}
+
+const char* WorldBindingsProvider::bindSpawnObject(const char* name, const float x, const float y, const float z)
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  if (!objectManager)
+  {
+    return store("");
+  }
+
+  // The default Object ctor already attaches a Transform. addObject assigns the manager + a fresh uuid.
+  auto object = std::make_shared<Object>(name ? std::string(name) : std::string("Object"));
+  objectManager->addObject(object);
+
+  // A script only runs while the scene is running, so the newborn must be started too (live component
+  // state) before its transform is positioned — otherwise physics/replication would read stopped values.
+  object->start();
+
+  if (const auto transform = object->getComponent<Transform>(ComponentType::transform))
+  {
+    transform->setPosition({ x, y, z });
+  }
+
+  // Record it so ServerApp can broadcast the spawn after the tick (scripting can't reach the net layer).
+  BindingContext::recordSpawn(object);
+
+  return store(uuids::to_string(object->getUUID()));
+}
+
+void WorldBindingsProvider::bindDestroyObject(const char* uuid)
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  if (!objectManager || !uuid)
+  {
+    return;
+  }
+
+  const auto parsed = uuids::uuid::from_string(std::string(uuid));
+  if (!parsed.has_value())
+  {
+    return;
+  }
+
+  const auto object = objectManager->getObjectByUUID(parsed.value());
+  if (!object)
+  {
+    return;
+  }
+
+  // Mark for deletion (never mutate the object list mid script iteration); ServerApp broadcasts the
+  // destroy and calls deleteObjectsMarkedForDeletion after the tick.
+  objectManager->removeObject(object);
+  BindingContext::recordDestroy(parsed.value());
 }

--- a/source/libs/scripting/bindings/WorldBindings.cpp
+++ b/source/libs/scripting/bindings/WorldBindings.cpp
@@ -1,0 +1,111 @@
+#include "WorldBindings.h"
+#include "BindingContext.h"
+#include <objects/Object.h>
+#include <objects/ObjectManager.h>
+#include <string>
+#include <utility>
+
+namespace {
+  // Returned strings point into this buffer, valid until the next WorldBindings call on the same
+  // thread. Scripts run synchronously on the server loop thread, so the managed caller marshals the
+  // result to a C# string immediately (see World.cs) before the next binding call overwrites it.
+  thread_local std::string s_returnBuffer;
+
+  const char* store(std::string value)
+  {
+    s_returnBuffer = std::move(value);
+    return s_returnBuffer.c_str();
+  }
+}
+
+WorldBindings WorldBindingsProvider::getBindings()
+{
+  return WorldBindings {
+    .findObjectByName = &bindFindObjectByName,
+    .getObjectName = &bindGetObjectName,
+    .objectExists = &bindObjectExists,
+    .getAllObjectUuids = &bindGetAllObjectUuids
+  };
+}
+
+const char* WorldBindingsProvider::bindFindObjectByName(const char* name)
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  if (!objectManager || !name)
+  {
+    return store("");
+  }
+
+  const std::string target(name);
+  for (const auto& object : objectManager->getAllObjects())
+  {
+    if (object->getName() == target)
+    {
+      return store(uuids::to_string(object->getUUID()));
+    }
+  }
+
+  return store("");
+}
+
+const char* WorldBindingsProvider::bindGetObjectName(const char* uuid)
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  if (!objectManager || !uuid)
+  {
+    return store("");
+  }
+
+  const auto parsed = uuids::uuid::from_string(std::string(uuid));
+  if (!parsed.has_value())
+  {
+    return store("");
+  }
+
+  const auto object = objectManager->getObjectByUUID(parsed.value());
+  if (!object)
+  {
+    return store("");
+  }
+
+  return store(object->getName());
+}
+
+bool WorldBindingsProvider::bindObjectExists(const char* uuid)
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  if (!objectManager || !uuid)
+  {
+    return false;
+  }
+
+  const auto parsed = uuids::uuid::from_string(std::string(uuid));
+  if (!parsed.has_value())
+  {
+    return false;
+  }
+
+  return objectManager->getObjectByUUID(parsed.value()) != nullptr;
+}
+
+const char* WorldBindingsProvider::bindGetAllObjectUuids()
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  if (!objectManager)
+  {
+    return store("");
+  }
+
+  // UUIDs never contain commas, so a comma-delimited list marshals back cleanly (see World.cs).
+  std::string result;
+  for (const auto& object : objectManager->getAllObjects())
+  {
+    if (!result.empty())
+    {
+      result += ',';
+    }
+    result += uuids::to_string(object->getUUID());
+  }
+
+  return store(result);
+}

--- a/source/libs/scripting/bindings/WorldBindings.h
+++ b/source/libs/scripting/bindings/WorldBindings.h
@@ -13,6 +13,8 @@ struct WorldBindings
   const char*(*getObjectName)(const char* uuid);
   bool(*objectExists)(const char* uuid);
   const char*(*getAllObjectUuids)();
+  const char*(*spawnObject)(const char* name, float x, float y, float z);
+  void(*destroyObject)(const char* uuid);
 };
 
 class WorldBindingsProvider {
@@ -24,6 +26,11 @@ private:
   static const char* bindGetObjectName(const char* uuid);
   static bool bindObjectExists(const char* uuid);
   static const char* bindGetAllObjectUuids();
+
+  // Spawn a minimal object (a Transform at the given position); returns its new uuid. Full prefab spawn
+  // arrives in Phase 5. destroyObject marks the object for deletion through the existing path.
+  static const char* bindSpawnObject(const char* name, float x, float y, float z);
+  static void bindDestroyObject(const char* uuid);
 };
 
 

--- a/source/libs/scripting/bindings/WorldBindings.h
+++ b/source/libs/scripting/bindings/WorldBindings.h
@@ -1,0 +1,31 @@
+#ifndef WORLDBINDINGS_H
+#define WORLDBINDINGS_H
+
+// Scene/world queries exposed to scripts. Mirrors the TransformBindings pattern: a C-ABI struct of
+// function pointers registered with the managed side through Bridge, resolved against the server's
+// current ObjectManager via BindingContext (set by ScriptSystem each tick).
+//
+// String returns point into a thread-local buffer owned by the native side; the managed caller marshals
+// them out immediately (see World.cs) and must not free them. String arguments are owned by the caller.
+struct WorldBindings
+{
+  const char*(*findObjectByName)(const char* name);
+  const char*(*getObjectName)(const char* uuid);
+  bool(*objectExists)(const char* uuid);
+  const char*(*getAllObjectUuids)();
+};
+
+class WorldBindingsProvider {
+public:
+  [[nodiscard]] static WorldBindings getBindings();
+
+private:
+  static const char* bindFindObjectByName(const char* name);
+  static const char* bindGetObjectName(const char* uuid);
+  static bool bindObjectExists(const char* uuid);
+  static const char* bindGetAllObjectUuids();
+};
+
+
+
+#endif //WORLDBINDINGS_H


### PR DESCRIPTION
This pull request introduces incremental replication of runtime object spawning and destruction, enabling scripts to efficiently create and remove objects at runtime without requiring full scene snapshots. The changes add new network message types and handlers to synchronize these structural changes across server, client, and editor, and update the scripting and documentation to reflect the new workflow. Additionally, scripting APIs are improved for script-to-script access, and the editor now supports vector3 fields in script components.

**Incremental runtime object replication:**

* Added new message types (`objectSpawned`, `objectDestroyed`) to `MessageType` and implemented corresponding message builders and appliers in `Replication.{h,cpp}` for efficient, incremental replication of objects created or destroyed by scripts at runtime. [[1]](diffhunk://#diff-6887c73a096b01563dea9ab13b83c427db5efc670a2be807167eef15e539bf8fL32-R34) [[2]](diffhunk://#diff-8d3d6c099c8fc01ec0c3687fcf11404380f958f32ffa16ae506bdf5f39312d1aR414-R458) [[3]](diffhunk://#diff-5125260ab551a8e4b9b0007faf66bd97c8ee3331c9788e5076589d48ddbf93d4R66-R77)
* Updated `ServerApp` to buffer and broadcast structural changes (spawn/destroy) after each script tick using `BindingContext`, ensuring clients receive these updates before state deltas. [[1]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR149-R152) [[2]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR575-R600) [[3]](diffhunk://#diff-59a6facf8f8f4ca802ec9e46466dd86b4d1fc813aeaea6dfbce95fae1f4f9292R100-R104)
* Modified `ClientApp` and `EditorApp` to handle and apply `objectSpawned` and `objectDestroyed` messages, updating the replicated scene accordingly. [[1]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaR189-R196) [[2]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaR230-R247) [[3]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aR82-R85) [[4]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R352-R359) [[5]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R400-R417) [[6]](diffhunk://#diff-9a5c9efc47e4a10dd5c55d5b1972613c1f81ca79c013e4d58c6cad5065890034R123-R126)

**Scripting system enhancements:**

* Exposed new script-to-script access APIs in `ScriptBase` and `Bridge`, allowing scripts to retrieve other scripts on the same or different objects, either by type or as a list. [[1]](diffhunk://#diff-aa660f289f813e6a62c6a5e8d293da4621f9687803a66c0d9e196fb183a30236R1-R2) [[2]](diffhunk://#diff-aa660f289f813e6a62c6a5e8d293da4621f9687803a66c0d9e196fb183a30236R19-R29) [[3]](diffhunk://#diff-afd32373dd1183a2b609fd56c4c4c5eb7c149652817cdb6e1431057546bf9617R5) [[4]](diffhunk://#diff-afd32373dd1183a2b609fd56c4c4c5eb7c149652817cdb6e1431057546bf9617R23-R31)
* Registered `WorldBindings` in the scripting library to support new native bindings, and documented the addition of `World` and `BindingContext` in the scripting architecture. [[1]](diffhunk://#diff-5d771a36956d2d6435aaeffc92b5485636f75ada3ed5ce6093b749dc8b6e6a89R16-R17) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L36-R36) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R92-R95) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L100-R115)

**Editor improvements:**

* Added support for editing `vector3` fields in script components via ImGui in the editor.

These changes collectively improve the efficiency and flexibility of runtime scene manipulation, scripting, and editor usability.