### PR TITLE
Enhance collision system with triggers, callbacks, and scene queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,11 +108,20 @@ bindings back to the server's live scene: `ScriptSystem` points it at the curren
 tick. The headless server has no GLFW window, so input is networked: clients send `inputState`, the
 server writes it into the global `InputState`, and `InputUtilsBindings` reads it back for scripts. Forces
 requested from a script are buffered on the `RigidBody` data (pending-force queue) and drained by
-`PhysicsSystem`, keeping `scripting` independent of `sim`. Two conventions worth inheriting: (1) reaching
+`PhysicsSystem`, keeping `scripting` independent of `sim`. Four conventions worth inheriting: (1) reaching
 another object's component is a **`tryGet`** (`World.tryGetTransform(uuid, out t)` → false when
 absent/destroyed; never throws in the tick loop) — future component wrappers follow this; (2) a binding
 that mutates scene structure can't touch the net layer, so it **buffers the change on `BindingContext`**
-and the app drains + replicates it after the tick (see the spawn/destroy path in Replication above).
+and the app drains + replicates it after the tick (see the spawn/destroy path in Replication above);
+(3) **sim→script events cross at the app, as plain data.** `CollisionSystem` records each tick's colliding
+pairs and diffs them into enter/stay/exit uuid-pair lists; `ServerApp` hands those to
+`ScriptSystem::dispatchCollisionEvent` (→ `onCollisionEnter/Stay/Exit` script virtuals) after the collision
+pass — the same "buffer plain data, let the app carry it" shape as pending forces, so `sim` never links
+`scripting`; (4) **sim→script *queries* cross by function-pointer injection.** Query behavior stays in a
+`sim` system (`SceneQueries`: raycast/overlapSphere), and `ServerApp` injects its statics into
+`BindingContext` (`setRaycast`/`setOverlapSphere`) at startup; the `World` bindings call through them. The
+injected signatures use only shared types (`ObjectManager`/`glm`/`uuid`), so no library learns the other —
+the pattern to reuse for any future sim query exposed to scripts.
 
 ## Development Principles
 

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -177,10 +177,36 @@ void ServerApp::fixedUpdate(const float dt) const
     m_scriptSystem->fixedUpdate(objectManager, dt);
     PhysicsSystem::fixedUpdate(objectManager, dt);
     m_collisionSystem->fixedUpdate(objectManager);
+
+    // Contact events for this tick: hand CollisionSystem's diffed pair lists to the scripts. Done here
+    // in the app (not as a library call) so sim stays independent of scripting — the collision system
+    // produces plain uuid pairs and ScriptSystem consumes them.
+    dispatchCollisionEvents(objectManager);
   }
   catch (const std::exception& e)
   {
     logMessage("Error", e.what());
+  }
+}
+
+void ServerApp::dispatchCollisionEvents(ObjectManager& objectManager) const
+{
+  // A collision pair notifies both of its objects (each learns of the other); ScriptSystem expands the
+  // pair into both directions and skips any object that was destroyed. Order enter/stay/exit so a script
+  // sees begin-before-persist and never a stale contact after it ended.
+  for (const auto& pair : m_collisionSystem->getCollisionEnters())
+  {
+    m_scriptSystem->dispatchCollisionEvent(objectManager, pair.a, pair.b, CollisionEvent::enter);
+  }
+
+  for (const auto& pair : m_collisionSystem->getCollisionStays())
+  {
+    m_scriptSystem->dispatchCollisionEvent(objectManager, pair.a, pair.b, CollisionEvent::stay);
+  }
+
+  for (const auto& pair : m_collisionSystem->getCollisionExits())
+  {
+    m_scriptSystem->dispatchCollisionEvent(objectManager, pair.a, pair.b, CollisionEvent::exit);
   }
 }
 
@@ -337,6 +363,9 @@ void ServerApp::handleLoadProject(const net::Message& message) const
 
   m_sceneManager->startScene();
 
+  // New project/scene: any contact history belongs to the project we just swapped out.
+  m_collisionSystem->reset();
+
   if (const auto scene = m_sceneManager->getCurrentScene())
   {
     try
@@ -438,6 +467,10 @@ void ServerApp::handleSceneControl(const net::Message& message) const
       if (previousStatus == SceneStatus::stopped)
       {
         m_scriptSystem->start(objectManager);
+
+        // Fresh run: drop any contact history from the previous run so its first tick doesn't fire
+        // spurious enter/exit events against stale pairs.
+        m_collisionSystem->reset();
       }
     }
     else if (op == net::SceneControlOp::pause)
@@ -450,6 +483,7 @@ void ServerApp::handleSceneControl(const net::Message& message) const
       {
         m_scriptSystem->stop(objectManager);
         m_sceneManager->resetScene();
+        m_collisionSystem->reset();
       }
     }
   }
@@ -492,6 +526,9 @@ void ServerApp::loadScene(const std::string& sceneUUID) const
 
   m_sceneManager->loadScene(scene);
   m_sceneManager->startScene();
+
+  // New scene: contact history from the previous scene is meaningless here.
+  m_collisionSystem->reset();
 
   try
   {

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -13,6 +13,7 @@
 #include <objects/components/Component.h>
 #include <PhysicsSystem.h>
 #include <CollisionSystem.h>
+#include <queries/SceneQueries.h>
 #include <ScriptSystem.h>
 #include <bindings/InputState.h>
 #include <bindings/BindingContext.h>
@@ -41,6 +42,11 @@ ServerApp::ServerApp(LaunchOptions options)
   m_collisionSystem = std::make_shared<CollisionSystem>();
   m_scriptSystem = std::make_shared<ScriptSystem>(m_host);
   m_netServer = std::make_shared<net::NetServer>(m_host);
+
+  // Scene queries live in sim, which scripting can't link; inject them into BindingContext so the World
+  // raycast/overlapSphere bindings can call them (the decided function-pointer injection for Phase 2.5).
+  BindingContext::setRaycast(&SceneQueries::raycast);
+  BindingContext::setOverlapSphere(&SceneQueries::overlapSphere);
 
   if (m_options.project.empty())
   {

--- a/source/apps/server/ServerApp.h
+++ b/source/apps/server/ServerApp.h
@@ -15,6 +15,7 @@ class ProjectSerializer;
 class ProjectPacker;
 class CollisionSystem;
 class ScriptSystem;
+class ObjectManager;
 
 namespace net {
   class NetServer;
@@ -69,6 +70,10 @@ private:
   bool m_hasConnected = false;
 
   void fixedUpdate(float dt) const;
+
+  // Feed this tick's collision enter/stay/exit pairs (from CollisionSystem) into the scripts. Bridges
+  // sim and scripting at the app level so neither library depends on the other.
+  void dispatchCollisionEvents(ObjectManager& objectManager) const;
 
   void handleClientMessage(const net::Message& message);
 

--- a/source/libs/data/objects/components/collisions/BoxCollider.cpp
+++ b/source/libs/data/objects/components/collisions/BoxCollider.cpp
@@ -70,7 +70,8 @@ nlohmann::json BoxCollider::serialize()
     { "subType", "Box" },
     { "position", { position.x, position.y, position.z } },
     { "rotation", { rotation.x, rotation.y, rotation.z } },
-    { "scale", { scale.x, scale.y, scale.z } }
+    { "scale", { scale.x, scale.y, scale.z } },
+    { "isTrigger", m_isTrigger }
   };
 
   return data;
@@ -85,6 +86,9 @@ void BoxCollider::loadFromJSON(const nlohmann::json& componentData)
   m_position.set(glm::vec3(position.at(0), position.at(1), position.at(2)));
   m_rotation.set(glm::vec3(rotation.at(0), rotation.at(1), rotation.at(2)));
   m_scale.set(glm::vec3(scale.at(0), scale.at(1), scale.at(2)));
+
+  // value() (not at()): projects saved before triggers existed have no isTrigger key.
+  m_isTrigger = componentData.value("isTrigger", false);
 
   m_meshDirty = true;
 }
@@ -152,6 +156,7 @@ void BoxCollider::pack(net::Message& message) const
   message.write(m_position.get());
   message.write(m_scale.get());
   message.write(m_rotation.get());
+  message.write(m_isTrigger);
 }
 
 void BoxCollider::unpack(net::MessageReader& messageReader)
@@ -160,6 +165,7 @@ void BoxCollider::unpack(net::MessageReader& messageReader)
   m_position.set(messageReader.read<glm::vec3>());
   m_scale.set(messageReader.read<glm::vec3>());
   m_rotation.set(messageReader.read<glm::vec3>());
+  m_isTrigger = messageReader.read<bool>();
 }
 
 void BoxCollider::generateTransformedMesh(const std::shared_ptr<Transform>& transform)

--- a/source/libs/data/objects/components/collisions/BoxCollider.cpp
+++ b/source/libs/data/objects/components/collisions/BoxCollider.cpp
@@ -71,7 +71,9 @@ nlohmann::json BoxCollider::serialize()
     { "position", { position.x, position.y, position.z } },
     { "rotation", { rotation.x, rotation.y, rotation.z } },
     { "scale", { scale.x, scale.y, scale.z } },
-    { "isTrigger", m_isTrigger }
+    { "isTrigger", m_isTrigger },
+    { "layer", m_layer },
+    { "mask", m_mask }
   };
 
   return data;
@@ -87,8 +89,10 @@ void BoxCollider::loadFromJSON(const nlohmann::json& componentData)
   m_rotation.set(glm::vec3(rotation.at(0), rotation.at(1), rotation.at(2)));
   m_scale.set(glm::vec3(scale.at(0), scale.at(1), scale.at(2)));
 
-  // value() (not at()): projects saved before triggers existed have no isTrigger key.
+  // value() (not at()): projects saved before triggers/layers existed have no such key.
   m_isTrigger = componentData.value("isTrigger", false);
+  m_layer = componentData.value("layer", 0u);
+  m_mask = componentData.value("mask", 0xFFFFFFFFu);
 
   m_meshDirty = true;
 }
@@ -157,6 +161,8 @@ void BoxCollider::pack(net::Message& message) const
   message.write(m_scale.get());
   message.write(m_rotation.get());
   message.write(m_isTrigger);
+  message.write(m_layer);
+  message.write(m_mask);
 }
 
 void BoxCollider::unpack(net::MessageReader& messageReader)
@@ -166,6 +172,8 @@ void BoxCollider::unpack(net::MessageReader& messageReader)
   m_scale.set(messageReader.read<glm::vec3>());
   m_rotation.set(messageReader.read<glm::vec3>());
   m_isTrigger = messageReader.read<bool>();
+  m_layer = messageReader.read<uint32_t>();
+  m_mask = messageReader.read<uint32_t>();
 }
 
 void BoxCollider::generateTransformedMesh(const std::shared_ptr<Transform>& transform)

--- a/source/libs/data/objects/components/collisions/Collider.cpp
+++ b/source/libs/data/objects/components/collisions/Collider.cpp
@@ -45,3 +45,13 @@ ColliderType Collider::getColliderType() const
 {
   return m_colliderType;
 }
+
+bool Collider::isTrigger() const
+{
+  return m_isTrigger;
+}
+
+void Collider::setIsTrigger(const bool isTrigger)
+{
+  m_isTrigger = isTrigger;
+}

--- a/source/libs/data/objects/components/collisions/Collider.cpp
+++ b/source/libs/data/objects/components/collisions/Collider.cpp
@@ -55,3 +55,24 @@ void Collider::setIsTrigger(const bool isTrigger)
 {
   m_isTrigger = isTrigger;
 }
+
+uint32_t Collider::getLayer() const
+{
+  return m_layer;
+}
+
+void Collider::setLayer(const uint32_t layer)
+{
+  // Only layers 0-31 exist (mask is 32 bits); clamp so a stray value can't shift out of range.
+  m_layer = layer > 31u ? 31u : layer;
+}
+
+uint32_t Collider::getMask() const
+{
+  return m_mask;
+}
+
+void Collider::setMask(const uint32_t mask)
+{
+  m_mask = mask;
+}

--- a/source/libs/data/objects/components/collisions/Collider.h
+++ b/source/libs/data/objects/components/collisions/Collider.h
@@ -32,6 +32,12 @@ public:
 
   [[nodiscard]] ColliderType getColliderType() const;
 
+  // A trigger still produces collision events but no physical response (no MTV correction, no
+  // impulses) — a volume scripts can react to without it blocking anything. Shared by every collider
+  // shape; each subclass threads it through its own serialize/loadFromJSON/pack/unpack.
+  [[nodiscard]] bool isTrigger() const;
+  void setIsTrigger(bool isTrigger);
+
   virtual glm::vec3 findFurthestPoint(const glm::vec3& direction) = 0;
 
   [[nodiscard]] virtual glm::vec3 getPosition() { return glm::vec3(0); }
@@ -44,6 +50,8 @@ protected:
   ColliderType m_colliderType;
 
   BoundingBox m_boundingBox;
+
+  bool m_isTrigger = false;
 };
 
 

--- a/source/libs/data/objects/components/collisions/Collider.h
+++ b/source/libs/data/objects/components/collisions/Collider.h
@@ -38,6 +38,16 @@ public:
   [[nodiscard]] bool isTrigger() const;
   void setIsTrigger(bool isTrigger);
 
+  // Broad-phase filtering. layer is this collider's layer index (0-31); mask is the set of layers it
+  // collides with (bit N = layer N). Two colliders interact only if each one's mask includes the other's
+  // layer, so a pair on non-matching layers is skipped before any narrow-phase / event work. Threaded
+  // through each subclass's serialize/loadFromJSON/pack/unpack like isTrigger.
+  [[nodiscard]] uint32_t getLayer() const;
+  void setLayer(uint32_t layer);
+
+  [[nodiscard]] uint32_t getMask() const;
+  void setMask(uint32_t mask);
+
   virtual glm::vec3 findFurthestPoint(const glm::vec3& direction) = 0;
 
   [[nodiscard]] virtual glm::vec3 getPosition() { return glm::vec3(0); }
@@ -52,6 +62,9 @@ protected:
   BoundingBox m_boundingBox;
 
   bool m_isTrigger = false;
+
+  uint32_t m_layer = 0;
+  uint32_t m_mask = 0xFFFFFFFFu;
 };
 
 

--- a/source/libs/data/objects/components/collisions/SphereCollider.cpp
+++ b/source/libs/data/objects/components/collisions/SphereCollider.cpp
@@ -64,7 +64,8 @@ nlohmann::json SphereCollider::serialize()
     { "subType", "Sphere" },
     { "radius", m_radius.getInitialValue() },
     { "renderCollider", m_renderCollider },
-    { "position", { position.x, position.y, position.z } }
+    { "position", { position.x, position.y, position.z } },
+    { "isTrigger", m_isTrigger }
   };
 
   return data;
@@ -77,6 +78,9 @@ void SphereCollider::loadFromJSON(const nlohmann::json& componentData)
 
   m_radius.set(componentData.at("radius"));
   m_renderCollider = componentData.at("renderCollider");
+
+  // value() (not at()): projects saved before triggers existed have no isTrigger key.
+  m_isTrigger = componentData.value("isTrigger", false);
 }
 
 glm::vec3 SphereCollider::getPosition()
@@ -107,6 +111,7 @@ void SphereCollider::pack(net::Message& message) const
   message.write(m_renderCollider);
   message.write(m_position.get());
   message.write(m_radius.get());
+  message.write(m_isTrigger);
 }
 
 void SphereCollider::unpack(net::MessageReader& messageReader)
@@ -114,6 +119,7 @@ void SphereCollider::unpack(net::MessageReader& messageReader)
   m_renderCollider = messageReader.read<bool>();
   m_position.set(messageReader.read<glm::vec3>());
   m_radius.set(messageReader.read<float>());
+  m_isTrigger = messageReader.read<bool>();
 }
 
 void SphereCollider::updateTransformPointer()

--- a/source/libs/data/objects/components/collisions/SphereCollider.cpp
+++ b/source/libs/data/objects/components/collisions/SphereCollider.cpp
@@ -65,7 +65,9 @@ nlohmann::json SphereCollider::serialize()
     { "radius", m_radius.getInitialValue() },
     { "renderCollider", m_renderCollider },
     { "position", { position.x, position.y, position.z } },
-    { "isTrigger", m_isTrigger }
+    { "isTrigger", m_isTrigger },
+    { "layer", m_layer },
+    { "mask", m_mask }
   };
 
   return data;
@@ -79,8 +81,10 @@ void SphereCollider::loadFromJSON(const nlohmann::json& componentData)
   m_radius.set(componentData.at("radius"));
   m_renderCollider = componentData.at("renderCollider");
 
-  // value() (not at()): projects saved before triggers existed have no isTrigger key.
+  // value() (not at()): projects saved before triggers/layers existed have no such key.
   m_isTrigger = componentData.value("isTrigger", false);
+  m_layer = componentData.value("layer", 0u);
+  m_mask = componentData.value("mask", 0xFFFFFFFFu);
 }
 
 glm::vec3 SphereCollider::getPosition()
@@ -112,6 +116,8 @@ void SphereCollider::pack(net::Message& message) const
   message.write(m_position.get());
   message.write(m_radius.get());
   message.write(m_isTrigger);
+  message.write(m_layer);
+  message.write(m_mask);
 }
 
 void SphereCollider::unpack(net::MessageReader& messageReader)
@@ -120,6 +126,8 @@ void SphereCollider::unpack(net::MessageReader& messageReader)
   m_position.set(messageReader.read<glm::vec3>());
   m_radius.set(messageReader.read<float>());
   m_isTrigger = messageReader.read<bool>();
+  m_layer = messageReader.read<uint32_t>();
+  m_mask = messageReader.read<uint32_t>();
 }
 
 void SphereCollider::updateTransformPointer()

--- a/source/libs/editor/components/ColliderEditor.cpp
+++ b/source/libs/editor/components/ColliderEditor.cpp
@@ -29,6 +29,13 @@ void registerColliderEditors(ComponentEditor& componentEditor)
         edited = true;
       }
 
+      bool isTrigger = box->isTrigger();
+      if (gc::accentCheckbox("Is Trigger", &isTrigger))
+      {
+        box->setIsTrigger(isTrigger);
+        edited = true;
+      }
+
       glm::vec3 position = box->getLocalPosition();
       glm::vec3 rotation = box->getLocalRotation();
       glm::vec3 scale = box->getLocalScale();
@@ -72,6 +79,13 @@ void registerColliderEditors(ComponentEditor& componentEditor)
       if (gc::accentCheckbox("Render Collider", &renderCollider))
       {
         sphere->setRenderCollider(renderCollider);
+        edited = true;
+      }
+
+      bool isTrigger = sphere->isTrigger();
+      if (gc::accentCheckbox("Is Trigger", &isTrigger))
+      {
+        sphere->setIsTrigger(isTrigger);
         edited = true;
       }
 

--- a/source/libs/editor/components/ColliderEditor.cpp
+++ b/source/libs/editor/components/ColliderEditor.cpp
@@ -1,11 +1,153 @@
 #include "ColliderEditor.h"
 #include "../ComponentEditor.h"
 #include "../GuiComponents.h"
+#include <objects/components/collisions/Collider.h>
 #include <objects/components/collisions/BoxCollider.h>
 #include <objects/components/collisions/SphereCollider.h>
 #include <glm/vec3.hpp>
 #include <imgui.h>
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
 #include <memory>
+#include <string>
+
+namespace {
+  // A one-line summary of which layers a mask includes, for the "Collides With" button face.
+  std::string maskSummary(const uint32_t mask)
+  {
+    if (mask == 0xFFFFFFFFu)
+    {
+      return "All layers";
+    }
+    if (mask == 0u)
+    {
+      return "Nothing";
+    }
+
+    std::string summary;
+    int listed = 0;
+    for (int i = 0; i < 32; ++i)
+    {
+      if ((mask & (1u << i)) == 0u)
+      {
+        continue;
+      }
+
+      if (listed == 6)
+      {
+        summary += ", ...";
+        break;
+      }
+
+      if (!summary.empty())
+      {
+        summary += ", ";
+      }
+      summary += std::to_string(i);
+      ++listed;
+    }
+
+    return summary;
+  }
+
+  // Layer index (0-31) + collision mask rows, shared by both collider shapes since the fields live on the
+  // Collider base. The mask is edited as per-layer checkboxes in a popup rather than a raw bitmask.
+  // Returns true if either was edited this frame.
+  bool colliderLayerMaskEditor(const std::shared_ptr<Collider>& collider)
+  {
+    bool edited = false;
+
+    // This collider's own layer: a drag field flanked by -/+ steppers.
+    int layer = static_cast<int>(collider->getLayer());
+    bool layerEdited = false;
+
+    gc::rowLabel("Layer");
+    ImGui::PushID("ColliderLayer");
+    const float step = ImGui::GetFrameHeight();
+    const float spacing = ImGui::GetStyle().ItemSpacing.x;
+    const float dragWidth = ImGui::GetContentRegionAvail().x - 2.0f * (step + spacing);
+
+    if (ImGui::Button("-", ImVec2(step, step)) && layer > 0)
+    {
+      --layer;
+      layerEdited = true;
+    }
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(dragWidth);
+    if (ImGui::DragInt("##layer", &layer, 0.1f, 0, 31))
+    {
+      layerEdited = true;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("+", ImVec2(step, step)) && layer < 31)
+    {
+      ++layer;
+      layerEdited = true;
+    }
+    ImGui::PopID();
+
+    if (layerEdited)
+    {
+      collider->setLayer(static_cast<uint32_t>(std::clamp(layer, 0, 31)));
+      edited = true;
+    }
+
+    // Which layers this collider collides with, as a checklist popup (bit N = layer N).
+    uint32_t mask = collider->getMask();
+    bool maskEdited = false;
+
+    gc::rowLabel("Collides With");
+    ImGui::PushID("ColliderMask");
+    if (ImGui::Button(maskSummary(mask).c_str(), ImVec2(ImGui::GetContentRegionAvail().x, 0.0f)))
+    {
+      ImGui::OpenPopup("maskPopup");
+    }
+
+    if (ImGui::BeginPopup("maskPopup"))
+    {
+      if (ImGui::SmallButton("All"))
+      {
+        mask = 0xFFFFFFFFu;
+        maskEdited = true;
+      }
+      ImGui::SameLine();
+      if (ImGui::SmallButton("None"))
+      {
+        mask = 0u;
+        maskEdited = true;
+      }
+
+      ImGui::Separator();
+
+      // 32 layers is tall; keep the list in a fixed, scrollable box.
+      ImGui::BeginChild("maskLayers", ImVec2(150.0f, 200.0f), false);
+      for (int i = 0; i < 32; ++i)
+      {
+        bool on = (mask & (1u << i)) != 0u;
+        char label[16];
+        std::snprintf(label, sizeof(label), "Layer %d", i);
+        if (ImGui::Checkbox(label, &on))
+        {
+          mask = on ? (mask | (1u << i)) : (mask & ~(1u << i));
+          maskEdited = true;
+        }
+      }
+      ImGui::EndChild();
+
+      ImGui::EndPopup();
+    }
+    ImGui::PopID();
+
+    if (maskEdited)
+    {
+      collider->setMask(mask);
+      edited = true;
+    }
+
+    return edited;
+  }
+}
 
 void registerColliderEditors(ComponentEditor& componentEditor)
 {
@@ -35,6 +177,8 @@ void registerColliderEditors(ComponentEditor& componentEditor)
         box->setIsTrigger(isTrigger);
         edited = true;
       }
+
+      edited |= colliderLayerMaskEditor(box);
 
       glm::vec3 position = box->getLocalPosition();
       glm::vec3 rotation = box->getLocalRotation();
@@ -88,6 +232,8 @@ void registerColliderEditors(ComponentEditor& componentEditor)
         sphere->setIsTrigger(isTrigger);
         edited = true;
       }
+
+      edited |= colliderLayerMaskEditor(sphere);
 
       float radius = sphere->getLocalRadius();
       if (gc::labeledDrag("Radius", &radius))

--- a/source/libs/scripting/ScriptBridge/ScriptBase.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBase.cs
@@ -31,4 +31,11 @@ public abstract class ScriptBase
     public virtual void fixedUpdate(float dt) {}
     public virtual void variableUpdate() {}
     public virtual void stop() {}
+
+    // Contact events, dispatched by the server after each tick's collision pass. otherUuid is the object
+    // this one is touching; onCollisionEnter fires the tick contact begins, onCollisionStay every tick it
+    // persists, onCollisionExit the tick it ends (otherUuid may already be destroyed by then).
+    public virtual void onCollisionEnter(string otherUuid) {}
+    public virtual void onCollisionStay(string otherUuid) {}
+    public virtual void onCollisionExit(string otherUuid) {}
 }

--- a/source/libs/scripting/ScriptBridge/ScriptBase.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace ScriptBridge;
 
@@ -26,6 +27,16 @@ public abstract class ScriptBase
     protected IReadOnlyList<ScriptBase> getScripts(string uuid) => Bridge.FindScripts(uuid);
 
     protected IReadOnlyList<ScriptBase> getScripts() => Bridge.FindScripts(EntityId);
+
+    // Scene queries that automatically ignore this script's own object, so a ray/overlap cast from an
+    // object never reports itself. Use these instead of the World.* versions unless you specifically want
+    // self included (World.raycast/overlapSphere take an optional ignoreUuid too).
+    protected bool raycast(Vector3 origin, Vector3 direction, float maxDistance, out RaycastHit hit,
+                           uint layerMask = 0xFFFFFFFF)
+        => World.raycast(origin, direction, maxDistance, out hit, layerMask, EntityId);
+
+    protected string[] overlapSphere(Vector3 center, float radius, uint layerMask = 0xFFFFFFFF)
+        => World.overlapSphere(center, radius, layerMask, EntityId);
 
     public virtual void start() {}
     public virtual void fixedUpdate(float dt) {}

--- a/source/libs/scripting/ScriptBridge/ScriptBridge.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBridge.cs
@@ -362,6 +362,25 @@ public static class Bridge
             instance.variableUpdate();
         }
     }
+
+    // eventType matches CollisionEvent in ScriptSystem.h: 0 = enter, 1 = stay, 2 = exit.
+    [UnmanagedCallersOnly]
+    public static void onCollision(IntPtr uuidPtr, IntPtr classNamePtr, IntPtr otherUuidPtr, int eventType)
+    {
+        var key = Key(Marshal.PtrToStringUTF8(uuidPtr)!, Marshal.PtrToStringUTF8(classNamePtr)!);
+        if (!_instances.TryGetValue(key, out var instance))
+        {
+            return;
+        }
+
+        var other = Marshal.PtrToStringUTF8(otherUuidPtr)!;
+        switch (eventType)
+        {
+            case 0: instance.onCollisionEnter(other); break;
+            case 1: instance.onCollisionStay(other); break;
+            case 2: instance.onCollisionExit(other); break;
+        }
+    }
 }
 
 internal sealed class ScriptContext : AssemblyLoadContext

--- a/source/libs/scripting/ScriptBridge/components/World.cs
+++ b/source/libs/scripting/ScriptBridge/components/World.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
@@ -13,6 +14,17 @@ public unsafe struct WorldBindings
     public delegate* unmanaged<IntPtr> getAllObjectUuids;
     public delegate* unmanaged<IntPtr, float, float, float, IntPtr> spawnObject;
     public delegate* unmanaged<IntPtr, void> destroyObject;
+    public delegate* unmanaged<float, float, float, float, float, float, float, uint, IntPtr, IntPtr> raycast;
+    public delegate* unmanaged<float, float, float, float, uint, IntPtr, IntPtr> overlapSphere;
+}
+
+// The result of a successful World.raycast: the object hit and where.
+public struct RaycastHit
+{
+    public string objectUuid;
+    public float distance;
+    public Vector3 point;
+    public Vector3 normal;
 }
 
 // World queries available to any user script: find objects, read names, and enumerate the scene.
@@ -144,6 +156,77 @@ public static unsafe class World
         finally
         {
             Marshal.FreeCoTaskMem(uuidPtr);
+        }
+    }
+
+    // Cast a ray against scene colliders. Returns true and fills `hit` with the nearest collider within
+    // maxDistance whose layer is in layerMask; false (and hit = default) on a miss. The math runs on the
+    // server via the sim query injected into BindingContext. Direction need not be normalized.
+    public static bool raycast(Vector3 origin, Vector3 direction, float maxDistance, out RaycastHit hit,
+                               uint layerMask = 0xFFFFFFFFu, string ignoreUuid = "")
+    {
+        hit = default;
+
+        var ignorePtr = Marshal.StringToCoTaskMemUTF8(ignoreUuid);
+        string raw;
+        try
+        {
+            // Native returns "uuid,dist,px,py,pz,nx,ny,nz" into its thread-local buffer, or "" on a miss;
+            // marshal it out immediately (return ownership is native's) and parse. ignoreUuid (our arg,
+            // our ownership) lets the caller exclude an object — used to skip self.
+            raw = Marshal.PtrToStringUTF8(NativeBindings.World.raycast(
+                origin.X, origin.Y, origin.Z, direction.X, direction.Y, direction.Z,
+                maxDistance, layerMask, ignorePtr)) ?? "";
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(ignorePtr);
+        }
+
+        if (raw.Length == 0)
+        {
+            return false;
+        }
+
+        var parts = raw.Split(',');
+        if (parts.Length != 8)
+        {
+            return false;
+        }
+
+        // std::to_string writes with the C locale ('.' decimal), so parse invariant to match.
+        hit = new RaycastHit
+        {
+            objectUuid = parts[0],
+            distance = float.Parse(parts[1], CultureInfo.InvariantCulture),
+            point = new Vector3(
+                float.Parse(parts[2], CultureInfo.InvariantCulture),
+                float.Parse(parts[3], CultureInfo.InvariantCulture),
+                float.Parse(parts[4], CultureInfo.InvariantCulture)),
+            normal = new Vector3(
+                float.Parse(parts[5], CultureInfo.InvariantCulture),
+                float.Parse(parts[6], CultureInfo.InvariantCulture),
+                float.Parse(parts[7], CultureInfo.InvariantCulture))
+        };
+        return true;
+    }
+
+    // Every object whose collider overlaps the given sphere and whose layer is in layerMask. Hand a
+    // returned uuid to tryGetTransform/tryGetRigidBody to act on it.
+    public static string[] overlapSphere(Vector3 center, float radius, uint layerMask = 0xFFFFFFFFu,
+                                         string ignoreUuid = "")
+    {
+        var ignorePtr = Marshal.StringToCoTaskMemUTF8(ignoreUuid);
+        try
+        {
+            var raw = Marshal.PtrToStringUTF8(NativeBindings.World.overlapSphere(
+                center.X, center.Y, center.Z, radius, layerMask, ignorePtr)) ?? "";
+
+            return raw.Length == 0 ? Array.Empty<string>() : raw.Split(',');
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(ignorePtr);
         }
     }
 }

--- a/source/libs/scripting/ScriptEngine.cpp
+++ b/source/libs/scripting/ScriptEngine.cpp
@@ -46,6 +46,7 @@ void ScriptEngine::init(const std::string& bridgeDir,
 
   m_fixedUpdate = reinterpret_cast<FixedUpdateFn>(resolve("fixedUpdate"));
   m_variableUpdate = reinterpret_cast<VariableUpdateFn>(resolve("variableUpdate"));
+  m_onCollision = reinterpret_cast<OnCollisionFn>(resolve("onCollision"));
 
   m_getExposedFields = reinterpret_cast<GetExposedFieldsFn>(resolve("getExposedFields"));
   m_freeString = reinterpret_cast<FreeStringFn>(resolve("freeString"));
@@ -158,6 +159,17 @@ void ScriptEngine::variableUpdate(const char* uuid,
   if (m_variableUpdate)
   {
     m_variableUpdate(uuid, className);
+  }
+}
+
+void ScriptEngine::onCollision(const char* uuid,
+                               const char* className,
+                               const char* otherUuid,
+                               const int event) const
+{
+  if (m_onCollision)
+  {
+    m_onCollision(uuid, className, otherUuid, event);
   }
 }
 

--- a/source/libs/scripting/ScriptEngine.h
+++ b/source/libs/scripting/ScriptEngine.h
@@ -39,6 +39,14 @@ public:
   void variableUpdate(const char* uuid,
                       const char* className) const;
 
+  // Forward a collision event to one script instance. event matches CollisionEvent in ScriptSystem.h
+  // (0 = enter, 1 = stay, 2 = exit); kept as a raw int here so the ABI layer stays free of scripting's
+  // semantic enum.
+  void onCollision(const char* uuid,
+                   const char* className,
+                   const char* otherUuid,
+                   int event) const;
+
   [[nodiscard]] std::string getExposedFields(const char* uuid,
                                              const char* className) const;
 
@@ -88,6 +96,7 @@ private:
   using StopFn = void(*)(const char*, const char*);
   using FixedUpdateFn = void(*)(const char*, const char*, float);
   using VariableUpdateFn = void(*)(const char*, const char*);
+  using OnCollisionFn = void(*)(const char*, const char*, const char*, int);
   using VoidFn = void(*)();
   using InitBridgeFn = void(*)(const char*);
 
@@ -113,6 +122,7 @@ private:
   StopFn m_stop = nullptr;
   FixedUpdateFn m_fixedUpdate = nullptr;
   VariableUpdateFn m_variableUpdate = nullptr;
+  OnCollisionFn m_onCollision = nullptr;
   VoidFn m_reload = nullptr;
 
   GetExposedFieldsFn m_getExposedFields = nullptr;

--- a/source/libs/scripting/ScriptSystem.cpp
+++ b/source/libs/scripting/ScriptSystem.cpp
@@ -155,6 +155,59 @@ void ScriptSystem::variableUpdate(ObjectManager& objectManager) const
   }
 }
 
+void ScriptSystem::dispatchCollisionEvent(ObjectManager& objectManager,
+                                          const uuids::uuid& objectA,
+                                          const uuids::uuid& objectB,
+                                          const CollisionEvent event) const
+{
+  if (!m_engine)
+  {
+    return;
+  }
+
+  // Point the bindings at the scene so a script's collision handler can resolve uuids (move, applyForce,
+  // World queries) while it runs, just like fixedUpdate does.
+  BindingContext::setObjectManager(&objectManager);
+
+  dispatchCollisionTo(objectManager, objectA, objectB, event);
+  dispatchCollisionTo(objectManager, objectB, objectA, event);
+}
+
+void ScriptSystem::dispatchCollisionTo(ObjectManager& objectManager,
+                                       const uuids::uuid& target,
+                                       const uuids::uuid& other,
+                                       const CollisionEvent event) const
+{
+  const auto object = objectManager.getObjectByUUID(target);
+  if (!object)
+  {
+    // The object was destroyed (e.g. this is the exit event for a contact that ended because it was
+    // removed). Nothing to notify on this side.
+    return;
+  }
+
+  const auto targetStr = uuids::to_string(target);
+  const auto otherStr = uuids::to_string(other);
+  const auto eventCode = static_cast<int>(event);
+
+  for (const auto& scriptComponent : object->getScripts())
+  {
+    const auto script = std::dynamic_pointer_cast<Script>(scriptComponent);
+    if (!script)
+    {
+      continue;
+    }
+
+    // Only notify instances that have been attached + started (mirrors variableUpdate's guard).
+    if (!isAttached(target, script->getClassName()))
+    {
+      continue;
+    }
+
+    m_engine->onCollision(targetStr.c_str(), script->getClassName().c_str(), otherStr.c_str(), eventCode);
+  }
+}
+
 void ScriptSystem::attachAll(ObjectManager& objectManager)
 {
   ensureEngine();

--- a/source/libs/scripting/ScriptSystem.h
+++ b/source/libs/scripting/ScriptSystem.h
@@ -16,6 +16,14 @@ class ObjectManager;
 class Object;
 class Script;
 
+// Which contact-lifecycle callback a dispatched collision event maps to. The integer values are the
+// wire contract with ScriptBridge.Bridge.onCollision (0 = enter, 1 = stay, 2 = exit) — keep them in sync.
+enum class CollisionEvent {
+  enter = 0,
+  stay = 1,
+  exit = 2
+};
+
 // Drives the live C# script instances on the server. Owns the ScriptEngine (the ScriptBridge ABI)
 // and tracks which (uuid, class) pairs are attached, the exposed-field cache, and the hot-reload
 // file snapshot. Each Script data component carries only a field blob; ScriptSystem syncs that blob
@@ -38,6 +46,15 @@ public:
   // so it runs this once per tick from the networked InputState; it must run before fixedUpdate so any
   // force the script queues from input is applied the same tick.
   void variableUpdate(ObjectManager& objectManager) const;
+
+  // Deliver one collision event to both objects' scripts: objectA's scripts learn of objectB and vice
+  // versa. Fed plain uuid pairs by the app (from CollisionSystem's enter/stay/exit lists) so scripting
+  // stays independent of sim. Safe if an object was destroyed (its side is skipped); the survivor still
+  // gets the event.
+  void dispatchCollisionEvent(ObjectManager& objectManager,
+                              const uuids::uuid& objectA,
+                              const uuids::uuid& objectB,
+                              CollisionEvent event) const;
 
   // Attach any scripts that haven't been attached yet (without running their lifecycle methods).
   // Call this before syncFieldsToData so newly added scripts have a field-cache entry.
@@ -80,6 +97,13 @@ private:
   void attach(const Object& object, const Script& script);
 
   void detach(const uuids::uuid& uuid, const std::string& className);
+
+  // Deliver one directed collision event: every attached script on `target` learns it is touching
+  // `other`. One half of dispatchCollisionEvent's both-directions delivery.
+  void dispatchCollisionTo(ObjectManager& objectManager,
+                           const uuids::uuid& target,
+                           const uuids::uuid& other,
+                           CollisionEvent event) const;
 
   void writeFieldsToInstance(const uuids::uuid& uuid,
                              const std::string& className,

--- a/source/libs/scripting/UserScripts/BlockScript.cs
+++ b/source/libs/scripting/UserScripts/BlockScript.cs
@@ -23,4 +23,17 @@ public class BlockScript : ScriptBase
     {
         Console.WriteLine("[BlockScript] Stopping.");
     }
+
+    public override void onCollisionEnter(string otherUuid)
+    {
+        Console.WriteLine($"[BlockScript] Collision ENTER with {otherUuid}");
+    }
+
+    // onCollisionStay fires every tick the contact persists — left unlogged here so it doesn't flood
+    // the console. Override it when you need per-tick contact logic.
+
+    public override void onCollisionExit(string otherUuid)
+    {
+        Console.WriteLine($"[BlockScript] Collision EXIT with {otherUuid}");
+    }
 }

--- a/source/libs/scripting/bindings/BindingContext.cpp
+++ b/source/libs/scripting/bindings/BindingContext.cpp
@@ -4,6 +4,8 @@
 ObjectManager* BindingContext::s_objectManager = nullptr;
 std::vector<std::shared_ptr<Object>> BindingContext::s_spawned;
 std::vector<uuids::uuid> BindingContext::s_destroyed;
+BindingContext::RaycastFn BindingContext::s_raycast = nullptr;
+BindingContext::OverlapSphereFn BindingContext::s_overlapSphere = nullptr;
 
 void BindingContext::setObjectManager(ObjectManager* objectManager)
 {
@@ -33,4 +35,24 @@ std::vector<std::shared_ptr<Object>> BindingContext::takeSpawned()
 std::vector<uuids::uuid> BindingContext::takeDestroyed()
 {
   return std::exchange(s_destroyed, {});
+}
+
+void BindingContext::setRaycast(const RaycastFn raycast)
+{
+  s_raycast = raycast;
+}
+
+BindingContext::RaycastFn BindingContext::getRaycast()
+{
+  return s_raycast;
+}
+
+void BindingContext::setOverlapSphere(const OverlapSphereFn overlapSphere)
+{
+  s_overlapSphere = overlapSphere;
+}
+
+BindingContext::OverlapSphereFn BindingContext::getOverlapSphere()
+{
+  return s_overlapSphere;
 }

--- a/source/libs/scripting/bindings/BindingContext.h
+++ b/source/libs/scripting/bindings/BindingContext.h
@@ -1,6 +1,8 @@
 #ifndef BINDINGCONTEXT_H
 #define BINDINGCONTEXT_H
 
+#include <glm/vec3.hpp>
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <uuid.h>
@@ -14,8 +16,17 @@ class ObjectManager;
 // Runtime spawn/destroy from a script can't broadcast directly (the bindings know nothing about the net
 // layer), so the spawn/destroy bindings record what happened here; ServerApp drains these after the tick
 // and replicates them (objectSpawned/objectDestroyed) — keeping scripting independent of net/protocol.
+//
+// Scene queries (raycast/overlap) live in sim, which scripting can't link, so the server app injects them
+// here as function pointers at startup (see SceneQueries); the World bindings call through them. Signatures
+// use only types both sides share (data + glm + uuid) and must match SceneQueries' statics.
 class BindingContext {
 public:
+  using RaycastFn = bool(*)(ObjectManager&, const glm::vec3&, const glm::vec3&, float, uint32_t,
+                            const uuids::uuid&, uuids::uuid&, glm::vec3&, glm::vec3&, float&);
+  using OverlapSphereFn = void(*)(ObjectManager&, const glm::vec3&, float, uint32_t,
+                                  const uuids::uuid&, std::vector<uuids::uuid>&);
+
   static void setObjectManager(ObjectManager* objectManager);
 
   [[nodiscard]] static ObjectManager* getObjectManager();
@@ -29,11 +40,20 @@ public:
 
   [[nodiscard]] static std::vector<uuids::uuid> takeDestroyed();
 
+  static void setRaycast(RaycastFn raycast);
+  [[nodiscard]] static RaycastFn getRaycast();
+
+  static void setOverlapSphere(OverlapSphereFn overlapSphere);
+  [[nodiscard]] static OverlapSphereFn getOverlapSphere();
+
 private:
   static ObjectManager* s_objectManager;
 
   static std::vector<std::shared_ptr<Object>> s_spawned;
   static std::vector<uuids::uuid> s_destroyed;
+
+  static RaycastFn s_raycast;
+  static OverlapSphereFn s_overlapSphere;
 };
 
 

--- a/source/libs/scripting/bindings/WorldBindings.cpp
+++ b/source/libs/scripting/bindings/WorldBindings.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace {
   // Returned strings point into this buffer, valid until the next WorldBindings call on the same
@@ -20,6 +21,18 @@ namespace {
     s_returnBuffer = std::move(value);
     return s_returnBuffer.c_str();
   }
+
+  // Parse an optional uuid argument; an empty/invalid string becomes the nil uuid, which the query
+  // treats as "ignore nothing" (real object uuids are never nil).
+  uuids::uuid parseIgnore(const char* uuid)
+  {
+    if (!uuid)
+    {
+      return {};
+    }
+
+    return uuids::uuid::from_string(std::string(uuid)).value_or(uuids::uuid{});
+  }
 }
 
 WorldBindings WorldBindingsProvider::getBindings()
@@ -30,7 +43,9 @@ WorldBindings WorldBindingsProvider::getBindings()
     .objectExists = &bindObjectExists,
     .getAllObjectUuids = &bindGetAllObjectUuids,
     .spawnObject = &bindSpawnObject,
-    .destroyObject = &bindDestroyObject
+    .destroyObject = &bindDestroyObject,
+    .raycast = &bindRaycast,
+    .overlapSphere = &bindOverlapSphere
   };
 }
 
@@ -167,4 +182,66 @@ void WorldBindingsProvider::bindDestroyObject(const char* uuid)
   // destroy and calls deleteObjectsMarkedForDeletion after the tick.
   objectManager->removeObject(object);
   BindingContext::recordDestroy(parsed.value());
+}
+
+const char* WorldBindingsProvider::bindRaycast(const float ox, const float oy, const float oz,
+                                               const float dx, const float dy, const float dz,
+                                               const float maxDistance, const uint32_t layerMask,
+                                               const char* ignoreUuid)
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  const auto raycast = BindingContext::getRaycast();
+  if (!objectManager || !raycast)
+  {
+    return store("");
+  }
+
+  uuids::uuid hitObject;
+  glm::vec3 hitPoint(0.0f);
+  glm::vec3 hitNormal(0.0f);
+  float hitDistance = 0.0f;
+
+  if (!raycast(*objectManager, { ox, oy, oz }, { dx, dy, dz }, maxDistance, layerMask,
+               parseIgnore(ignoreUuid), hitObject, hitPoint, hitNormal, hitDistance))
+  {
+    return store("");
+  }
+
+  // "uuid,dist,px,py,pz,nx,ny,nz" — uuids have no commas, so this parses cleanly on the managed side.
+  std::string result = uuids::to_string(hitObject);
+  for (const float value : { hitDistance, hitPoint.x, hitPoint.y, hitPoint.z,
+                             hitNormal.x, hitNormal.y, hitNormal.z })
+  {
+    result += ',';
+    result += std::to_string(value);
+  }
+
+  return store(result);
+}
+
+const char* WorldBindingsProvider::bindOverlapSphere(const float cx, const float cy, const float cz,
+                                                     const float radius, const uint32_t layerMask,
+                                                     const char* ignoreUuid)
+{
+  const auto objectManager = BindingContext::getObjectManager();
+  const auto overlapSphere = BindingContext::getOverlapSphere();
+  if (!objectManager || !overlapSphere)
+  {
+    return store("");
+  }
+
+  std::vector<uuids::uuid> results;
+  overlapSphere(*objectManager, { cx, cy, cz }, radius, layerMask, parseIgnore(ignoreUuid), results);
+
+  std::string out;
+  for (const auto& uuid : results)
+  {
+    if (!out.empty())
+    {
+      out += ',';
+    }
+    out += uuids::to_string(uuid);
+  }
+
+  return store(out);
 }

--- a/source/libs/scripting/bindings/WorldBindings.h
+++ b/source/libs/scripting/bindings/WorldBindings.h
@@ -1,6 +1,8 @@
 #ifndef WORLDBINDINGS_H
 #define WORLDBINDINGS_H
 
+#include <cstdint>
+
 // Scene/world queries exposed to scripts. Mirrors the TransformBindings pattern: a C-ABI struct of
 // function pointers registered with the managed side through Bridge, resolved against the server's
 // current ObjectManager via BindingContext (set by ScriptSystem each tick).
@@ -15,6 +17,10 @@ struct WorldBindings
   const char*(*getAllObjectUuids)();
   const char*(*spawnObject)(const char* name, float x, float y, float z);
   void(*destroyObject)(const char* uuid);
+  const char*(*raycast)(float ox, float oy, float oz, float dx, float dy, float dz,
+                        float maxDistance, uint32_t layerMask, const char* ignoreUuid);
+  const char*(*overlapSphere)(float cx, float cy, float cz, float radius, uint32_t layerMask,
+                              const char* ignoreUuid);
 };
 
 class WorldBindingsProvider {
@@ -31,6 +37,14 @@ private:
   // arrives in Phase 5. destroyObject marks the object for deletion through the existing path.
   static const char* bindSpawnObject(const char* name, float x, float y, float z);
   static void bindDestroyObject(const char* uuid);
+
+  // Ray/overlap queries delegate to the sim implementation the app injected into BindingContext. Both
+  // return a comma-delimited string the managed side parses: raycast → "uuid,dist,px,py,pz,nx,ny,nz" (or
+  // "" on a miss); overlapSphere → a comma-separated uuid list (or "").
+  static const char* bindRaycast(float ox, float oy, float oz, float dx, float dy, float dz,
+                                 float maxDistance, uint32_t layerMask, const char* ignoreUuid);
+  static const char* bindOverlapSphere(float cx, float cy, float cz, float radius, uint32_t layerMask,
+                                       const char* ignoreUuid);
 };
 
 

--- a/source/libs/sim/CMakeLists.txt
+++ b/source/libs/sim/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(${PROJECT_NAME}
   collisions/Polytope.h
   collisions/Support.cpp
   collisions/Support.h
+  queries/SceneQueries.cpp
+  queries/SceneQueries.h
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/source/libs/sim/CollisionSystem.cpp
+++ b/source/libs/sim/CollisionSystem.cpp
@@ -147,6 +147,12 @@ void CollisionSystem::handleCollisions(const std::shared_ptr<RigidBody>& rigidBo
 {
   if (collidedObjects.size() == 1)
   {
+    // Triggers still recorded the pair (events fire), but get no MTV correction / impulse.
+    if (isTriggerPair(collider, collidedObjects[0]))
+    {
+      return;
+    }
+
     glm::vec3 mtv;
     glm::vec3 collisionPoint;
     if (collidesWith(collider, collidedObjects[0], &mtv, &collisionPoint))
@@ -184,6 +190,11 @@ void CollisionSystem::handleCollisions(const std::shared_ptr<RigidBody>& rigidBo
       {
         chosenFlags[j] = true;
 
+        if (isTriggerPair(collider, collidedObjects[j]))
+        {
+          continue;
+        }
+
         glm::vec3 mtv;
         glm::vec3 collisionPoint;
         if (collidesWith(collider, collidedObjects[j], &mtv, &collisionPoint))
@@ -193,6 +204,17 @@ void CollisionSystem::handleCollisions(const std::shared_ptr<RigidBody>& rigidBo
       }
     }
   }
+}
+
+bool CollisionSystem::isTriggerPair(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other)
+{
+  if (collider->isTrigger())
+  {
+    return true;
+  }
+
+  const auto otherCollider = other->getComponent<Collider>(ComponentType::collider);
+  return otherCollider && otherCollider->isTrigger();
 }
 
 bool CollisionSystem::collidesWith(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other,

--- a/source/libs/sim/CollisionSystem.cpp
+++ b/source/libs/sim/CollisionSystem.cpp
@@ -85,7 +85,8 @@ void CollisionSystem::recordCollisionEvents(const std::vector<std::vector<std::s
   }
 
   std::ranges::sort(current);
-  current.erase(std::ranges::unique(current).begin(), current.end());
+  auto uniqueRange = std::ranges::unique(current);
+  current.erase(uniqueRange.begin(), current.end());
 
   // Diff against the previous tick. Both sets are sorted, so the enter/stay/exit split is three linear
   // set operations rather than an O(n^2) rescan.

--- a/source/libs/sim/CollisionSystem.cpp
+++ b/source/libs/sim/CollisionSystem.cpp
@@ -126,6 +126,14 @@ void CollisionSystem::findCollisions(const CollisionEdge& edge, std::vector<std:
       break;
     }
 
+    // Layer/mask filter: skip pairs that don't share a collision layer before any narrow-phase or event
+    // work, so filtered layers produce neither a physical response nor a collision event. Kept after the
+    // sweep-and-prune break so the early-out still fires for beyond-range colliders on any layer.
+    if (!layersCollide(edge.collider, other.collider))
+    {
+      continue;
+    }
+
     const auto otherBbox = other.collider->getBoundingBox();
 
     if (bbox.maxX < otherBbox.minX || bbox.minX > otherBbox.maxX ||
@@ -215,6 +223,15 @@ bool CollisionSystem::isTriggerPair(const std::shared_ptr<Collider>& collider, c
 
   const auto otherCollider = other->getComponent<Collider>(ComponentType::collider);
   return otherCollider && otherCollider->isTrigger();
+}
+
+bool CollisionSystem::layersCollide(const std::shared_ptr<Collider>& a, const std::shared_ptr<Collider>& b)
+{
+  // layer is 0-31 (clamped in Collider::setLayer), so the shift stays in range.
+  const uint32_t aBit = 1u << a->getLayer();
+  const uint32_t bBit = 1u << b->getLayer();
+
+  return (a->getMask() & bBit) != 0u && (b->getMask() & aBit) != 0u;
 }
 
 bool CollisionSystem::collidesWith(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other,

--- a/source/libs/sim/CollisionSystem.cpp
+++ b/source/libs/sim/CollisionSystem.cpp
@@ -11,6 +11,7 @@
 #include <objects/components/collisions/SphereCollider.h>
 #include <glm/glm.hpp>
 #include <algorithm>
+#include <iterator>
 
 void CollisionSystem::fixedUpdate(const ObjectManager& objectManager)
 {
@@ -39,7 +40,11 @@ void CollisionSystem::checkCollisions()
     return a.position < b.position;
   });
 
-#pragma omp parallel for default(none) num_threads(6)
+  // Each edge's collided objects, indexed by edge so the parallel loop can record them lock-free (every
+  // thread writes only its own slot). Drained serially into the pair set once the loop finishes.
+  std::vector<std::vector<std::shared_ptr<Object>>> perEdgeCollisions(m_collisionEdges.size());
+
+#pragma omp parallel for default(none) shared(perEdgeCollisions) num_threads(6)
   for (int i = 0; i < m_collisionEdges.size(); ++i)
   {
     const auto& edge = m_collisionEdges[i];
@@ -57,8 +62,50 @@ void CollisionSystem::checkCollisions()
     if (!collidedObjects.empty())
     {
       handleCollisions(rigidBody, edge.collider, collidedObjects);
+      perEdgeCollisions[i] = std::move(collidedObjects);
     }
   }
+
+  recordCollisionEvents(perEdgeCollisions);
+}
+
+void CollisionSystem::recordCollisionEvents(const std::vector<std::vector<std::shared_ptr<Object>>>& perEdgeCollisions)
+{
+  // Flatten the per-edge results into this tick's canonical pair set. A dynamic-vs-dynamic contact is
+  // detected from both sides, so canonicalize (a < b) and dedupe.
+  std::vector<CollisionPair> current;
+  for (size_t i = 0; i < perEdgeCollisions.size(); ++i)
+  {
+    const auto& selfUUID = m_collisionEdges[i].object->getUUID();
+
+    for (const auto& other : perEdgeCollisions[i])
+    {
+      current.push_back(CollisionPair::make(selfUUID, other->getUUID()));
+    }
+  }
+
+  std::ranges::sort(current);
+  current.erase(std::ranges::unique(current).begin(), current.end());
+
+  // Diff against the previous tick. Both sets are sorted, so the enter/stay/exit split is three linear
+  // set operations rather than an O(n^2) rescan.
+  m_enters.clear();
+  m_stays.clear();
+  m_exits.clear();
+
+  std::ranges::set_difference(current, m_previousPairs, std::back_inserter(m_enters));
+  std::ranges::set_intersection(current, m_previousPairs, std::back_inserter(m_stays));
+  std::ranges::set_difference(m_previousPairs, current, std::back_inserter(m_exits));
+
+  m_previousPairs = std::move(current);
+}
+
+void CollisionSystem::reset()
+{
+  m_previousPairs.clear();
+  m_enters.clear();
+  m_stays.clear();
+  m_exits.clear();
 }
 
 void CollisionSystem::findCollisions(const CollisionEdge& edge, std::vector<std::shared_ptr<Object>>& collidedObjects) const

--- a/source/libs/sim/CollisionSystem.cpp
+++ b/source/libs/sim/CollisionSystem.cpp
@@ -85,7 +85,7 @@ void CollisionSystem::recordCollisionEvents(const std::vector<std::vector<std::s
   }
 
   std::ranges::sort(current);
-  current.erase(std::ranges::unique(current).begin(), current.end());
+  current.erase(std::unique(current.begin(), current.end()), current.end());
 
   // Diff against the previous tick. Both sets are sorted, so the enter/stay/exit split is three linear
   // set operations rather than an O(n^2) rescan.

--- a/source/libs/sim/CollisionSystem.cpp
+++ b/source/libs/sim/CollisionSystem.cpp
@@ -85,8 +85,7 @@ void CollisionSystem::recordCollisionEvents(const std::vector<std::vector<std::s
   }
 
   std::ranges::sort(current);
-  auto uniqueRange = std::ranges::unique(current);
-  current.erase(uniqueRange.begin(), current.end());
+  current.erase(std::ranges::unique(current).begin(), current.end());
 
   // Diff against the previous tick. Both sets are sorted, so the enter/stay/exit split is three linear
   // set operations rather than an O(n^2) rescan.

--- a/source/libs/sim/CollisionSystem.h
+++ b/source/libs/sim/CollisionSystem.h
@@ -76,6 +76,9 @@ private:
   // A contact is a trigger (events fire, but no physical response) if either collider is flagged as one.
   static bool isTriggerPair(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other);
 
+  // Broad-phase layer filter: true only if each collider's mask includes the other's layer.
+  static bool layersCollide(const std::shared_ptr<Collider>& a, const std::shared_ptr<Collider>& b);
+
   // GJK/EPA narrow phase, lifted out of Collider.
   static bool collidesWith(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other,
                            glm::vec3* mtv, glm::vec3* collisionPoint);

--- a/source/libs/sim/CollisionSystem.h
+++ b/source/libs/sim/CollisionSystem.h
@@ -73,6 +73,9 @@ private:
   static void handleCollisions(const std::shared_ptr<RigidBody>& rigidBody, const std::shared_ptr<Collider>& collider,
                                const std::vector<std::shared_ptr<Object>>& collidedObjects);
 
+  // A contact is a trigger (events fire, but no physical response) if either collider is flagged as one.
+  static bool isTriggerPair(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other);
+
   // GJK/EPA narrow phase, lifted out of Collider.
   static bool collidesWith(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other,
                            glm::vec3* mtv, glm::vec3* collisionPoint);

--- a/source/libs/sim/CollisionSystem.h
+++ b/source/libs/sim/CollisionSystem.h
@@ -2,8 +2,10 @@
 #define COLLISIONSYSTEM_H
 
 #include <glm/vec3.hpp>
+#include <compare>
 #include <memory>
 #include <vector>
+#include <uuid.h>
 
 class ObjectManager;
 class Object;
@@ -17,14 +19,54 @@ struct CollisionEdge {
   float position;
 };
 
+// An unordered colliding pair, stored canonically (a < b) so the same contact recorded from either
+// object's side dedupes to one entry. Plain uuids so the app can hand collision events to ScriptSystem
+// without sim depending on scripting.
+struct CollisionPair {
+  uuids::uuid a;
+  uuids::uuid b;
+
+  static CollisionPair make(const uuids::uuid& x, const uuids::uuid& y)
+  {
+    return x < y ? CollisionPair{x, y} : CollisionPair{y, x};
+  }
+
+  // Lexicographic by (a, b). Defaulting the three-way comparison gives the full set of relational
+  // operators (uuid has only < and ==, which the compiler synthesizes from), so CollisionPair models
+  // totally_ordered — required by std::ranges::sort / set_difference.
+  std::strong_ordering operator<=>(const CollisionPair& other) const = default;
+};
+
 class CollisionSystem {
 public:
   void fixedUpdate(const ObjectManager& objectManager);
 
+  // Collision events for the most recent tick, diffed against the tick before it. enters = pairs new
+  // this tick, stays = pairs present both ticks, exits = pairs gone this tick. Sorted; consumed by the
+  // app to dispatch onCollisionEnter/Stay/Exit into scripts.
+  [[nodiscard]] const std::vector<CollisionPair>& getCollisionEnters() const { return m_enters; }
+  [[nodiscard]] const std::vector<CollisionPair>& getCollisionStays() const { return m_stays; }
+  [[nodiscard]] const std::vector<CollisionPair>& getCollisionExits() const { return m_exits; }
+
+  // Clear the recorded pair history + event lists. Call on a scene start/stop/switch so contacts from a
+  // previous run don't leak into the next run's first diff as spurious enter/exit events.
+  void reset();
+
 private:
   std::vector<CollisionEdge> m_collisionEdges;
 
+  // Sorted set of colliding pairs from the previous tick, diffed against the current tick to produce
+  // the enter/stay/exit lists.
+  std::vector<CollisionPair> m_previousPairs;
+  std::vector<CollisionPair> m_enters;
+  std::vector<CollisionPair> m_stays;
+  std::vector<CollisionPair> m_exits;
+
   void checkCollisions();
+
+  // Build this tick's sorted pair set from the per-edge collision results and diff it against the
+  // previous tick to refresh m_enters/m_stays/m_exits.
+  void recordCollisionEvents(const std::vector<std::vector<std::shared_ptr<Object>>>& perEdgeCollisions);
 
   void findCollisions(const CollisionEdge& edge, std::vector<std::shared_ptr<Object>>& collidedObjects) const;
 

--- a/source/libs/sim/queries/SceneQueries.cpp
+++ b/source/libs/sim/queries/SceneQueries.cpp
@@ -1,0 +1,283 @@
+#include "SceneQueries.h"
+#include <objects/Object.h>
+#include <objects/ObjectManager.h>
+#include <objects/components/Component.h>
+#include <objects/components/Transform.h>
+#include <objects/components/collisions/Collider.h>
+#include <objects/components/collisions/BoxCollider.h>
+#include <objects/components/collisions/SphereCollider.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <utility>
+
+namespace {
+  constexpr float kEpsilon = 1e-8f;
+
+  bool layerInMask(const std::shared_ptr<Collider>& collider, const uint32_t layerMask)
+  {
+    return (layerMask & (1u << collider->getLayer())) != 0u;
+  }
+
+  // The box's world matrix, built the same way BoxCollider::generateTransformedMesh does (note: the box's
+  // own getScale() adds transform+local, but the collision mesh multiplies — so mirror the mesh here so
+  // ray/overlap match what actually collides). Maps the unit box [-1,1]^3 into world space.
+  glm::mat4 boxWorldMatrix(const std::shared_ptr<Transform>& transform, const std::shared_ptr<BoxCollider>& box)
+  {
+    const glm::vec3 position = transform->getPosition() + box->getLocalPosition();
+    const glm::vec3 rotation = transform->getRotation() + box->getLocalRotation();
+    const glm::vec3 scale = transform->getScale() * box->getLocalScale();
+
+    return translate(glm::mat4(1.0f), position)
+      * rotate(glm::mat4(1.0f), glm::radians(rotation.z), {0, 0, 1})
+      * rotate(glm::mat4(1.0f), glm::radians(rotation.y), {0, 1, 0})
+      * rotate(glm::mat4(1.0f), glm::radians(rotation.x), {1, 0, 0})
+      * glm::scale(glm::mat4(1.0f), scale);
+  }
+
+  // Ray vs sphere. dir must be normalized. Writes the nearest forward hit distance + surface normal.
+  bool raySphere(const glm::vec3& origin, const glm::vec3& dir, const glm::vec3& center, const float radius,
+                 const float maxDistance, float& tHit, glm::vec3& normal)
+  {
+    const glm::vec3 oc = origin - center;
+    const float b = dot(oc, dir);
+    const float c = dot(oc, oc) - radius * radius;
+    const float discriminant = b * b - c;
+
+    if (discriminant < 0.0f)
+    {
+      return false;
+    }
+
+    const float sq = std::sqrt(discriminant);
+    const float tNear = -b - sq;
+    const float tFar = -b + sq;
+
+    if (tFar < 0.0f)
+    {
+      return false; // sphere entirely behind the origin
+    }
+
+    // Origin inside the sphere (near root behind us) → report contact at the origin, so a ray started
+    // inside a collider (e.g. a body resting on/penetrating it) still detects it.
+    const float t = std::max(tNear, 0.0f);
+    if (t > maxDistance)
+    {
+      return false;
+    }
+
+    tHit = t;
+    const glm::vec3 offset = (origin + dir * t) - center;
+    const float offsetLength = length(offset);
+    normal = offsetLength > kEpsilon ? offset / offsetLength : -dir;
+    return true;
+  }
+
+  // Ray vs oriented box, via the box's world matrix: bring the ray into the box's local [-1,1]^3 space
+  // (the transform is linear, so the ray parameter t is preserved and is world distance since dir is
+  // normalized) and slab-test. dir must be normalized.
+  bool rayBox(const glm::vec3& origin, const glm::vec3& dir, const glm::mat4& boxMatrix,
+              const float maxDistance, float& tHit, glm::vec3& normal)
+  {
+    const glm::mat4 inverseMatrix = inverse(boxMatrix);
+    const glm::vec3 localOrigin = glm::vec3(inverseMatrix * glm::vec4(origin, 1.0f));
+    const glm::vec3 localDir = glm::vec3(inverseMatrix * glm::vec4(dir, 0.0f));
+
+    float tMin = -std::numeric_limits<float>::max();
+    float tMax = std::numeric_limits<float>::max();
+    int hitAxis = -1;
+    float hitSign = 1.0f;
+
+    for (int axis = 0; axis < 3; ++axis)
+    {
+      if (std::abs(localDir[axis]) < kEpsilon)
+      {
+        // Ray parallel to this slab: miss if it starts outside the slab.
+        if (localOrigin[axis] < -1.0f || localOrigin[axis] > 1.0f)
+        {
+          return false;
+        }
+        continue;
+      }
+
+      const float inv = 1.0f / localDir[axis];
+      float t1 = (-1.0f - localOrigin[axis]) * inv; // -1 face
+      float t2 = (1.0f - localOrigin[axis]) * inv;  // +1 face
+      float entrySign = -1.0f;                      // entering the -1 face → local normal -axis
+      if (t1 > t2)
+      {
+        std::swap(t1, t2);
+        entrySign = 1.0f; // entering the +1 face → local normal +axis
+      }
+
+      if (t1 > tMin)
+      {
+        tMin = t1;
+        hitAxis = axis;
+        hitSign = entrySign;
+      }
+      tMax = std::min(tMax, t2);
+
+      if (tMin > tMax)
+      {
+        return false;
+      }
+    }
+
+    // tMax < 0 means the whole box is behind the origin. tMin < 0 <= tMax means the origin is inside the
+    // box → report contact at the origin (t = 0), so a ray started inside a collider still detects it.
+    if (hitAxis < 0 || tMax < 0.0f)
+    {
+      return false;
+    }
+
+    const float t = std::max(tMin, 0.0f);
+    if (t > maxDistance)
+    {
+      return false;
+    }
+
+    glm::vec3 localNormal(0.0f);
+    localNormal[hitAxis] = hitSign;
+
+    // Transform the local face normal to world with the normal matrix (inverse-transpose of the linear
+    // part), so non-uniform box scale doesn't skew it.
+    tHit = t;
+    normal = normalize(glm::mat3(transpose(inverseMatrix)) * localNormal);
+    return true;
+  }
+
+  // Whether a sphere overlaps an oriented box, via the closest point on the box to the sphere centre.
+  bool sphereOverlapsBox(const glm::vec3& center, const float radius, const glm::mat4& boxMatrix)
+  {
+    // Box centre + the (scaled) axes are the columns of the world matrix; length of each column is the
+    // half-extent along that axis, the normalized column is the axis direction.
+    const glm::vec3 boxCenter = glm::vec3(boxMatrix[3]);
+    const glm::vec3 delta = center - boxCenter;
+
+    glm::vec3 closest = boxCenter;
+    for (int axis = 0; axis < 3; ++axis)
+    {
+      const glm::vec3 column = glm::vec3(boxMatrix[axis]);
+      const float extent = length(column);
+      if (extent < kEpsilon)
+      {
+        continue;
+      }
+
+      const glm::vec3 direction = column / extent;
+      const float distance = std::clamp(dot(delta, direction), -extent, extent);
+      closest += direction * distance;
+    }
+
+    return dot(center - closest, center - closest) <= radius * radius;
+  }
+}
+
+bool SceneQueries::raycast(ObjectManager& objectManager,
+                           const glm::vec3& origin, const glm::vec3& direction, const float maxDistance,
+                           const uint32_t layerMask, const uuids::uuid& ignoreObject,
+                           uuids::uuid& hitObject, glm::vec3& hitPoint, glm::vec3& hitNormal, float& hitDistance)
+{
+  const float dirLength = length(direction);
+  if (dirLength < kEpsilon)
+  {
+    return false;
+  }
+  const glm::vec3 dir = direction / dirLength;
+
+  bool hitAnything = false;
+  float nearest = maxDistance;
+
+  for (const auto& object : objectManager.getAllObjects())
+  {
+    if (object->getUUID() == ignoreObject)
+    {
+      continue; // skip the caster's own object (nil ignoreObject matches nothing)
+    }
+
+    const auto collider = object->getComponent<Collider>(ComponentType::collider);
+    if (!collider || !layerInMask(collider, layerMask))
+    {
+      continue;
+    }
+
+    float t = 0.0f;
+    glm::vec3 normal(0.0f);
+    bool hit = false;
+
+    if (collider->getColliderType() == ColliderType::sphereCollider)
+    {
+      const auto sphere = std::dynamic_pointer_cast<SphereCollider>(collider);
+      hit = raySphere(origin, dir, sphere->getPosition(), sphere->getRadius(), nearest, t, normal);
+    }
+    else
+    {
+      const auto box = std::dynamic_pointer_cast<BoxCollider>(collider);
+      const auto transform = object->getComponent<Transform>(ComponentType::transform);
+      if (box && transform)
+      {
+        hit = rayBox(origin, dir, boxWorldMatrix(transform, box), nearest, t, normal);
+      }
+    }
+
+    if (hit && t <= nearest)
+    {
+      hitAnything = true;
+      nearest = t;
+      hitObject = object->getUUID();
+      hitPoint = origin + dir * t;
+      hitNormal = normal;
+      hitDistance = t;
+    }
+  }
+
+  return hitAnything;
+}
+
+void SceneQueries::overlapSphere(ObjectManager& objectManager,
+                                 const glm::vec3& center, const float radius, const uint32_t layerMask,
+                                 const uuids::uuid& ignoreObject,
+                                 std::vector<uuids::uuid>& results)
+{
+  for (const auto& object : objectManager.getAllObjects())
+  {
+    if (object->getUUID() == ignoreObject)
+    {
+      continue; // skip the caster's own object (nil ignoreObject matches nothing)
+    }
+
+    const auto collider = object->getComponent<Collider>(ComponentType::collider);
+    if (!collider || !layerInMask(collider, layerMask))
+    {
+      continue;
+    }
+
+    bool overlaps = false;
+
+    if (collider->getColliderType() == ColliderType::sphereCollider)
+    {
+      const auto sphere = std::dynamic_pointer_cast<SphereCollider>(collider);
+      const glm::vec3 delta = sphere->getPosition() - center;
+      const float combined = sphere->getRadius() + radius;
+      overlaps = dot(delta, delta) <= combined * combined;
+    }
+    else
+    {
+      const auto box = std::dynamic_pointer_cast<BoxCollider>(collider);
+      const auto transform = object->getComponent<Transform>(ComponentType::transform);
+      if (box && transform)
+      {
+        overlaps = sphereOverlapsBox(center, radius, boxWorldMatrix(transform, box));
+      }
+    }
+
+    if (overlaps)
+    {
+      results.push_back(object->getUUID());
+    }
+  }
+}

--- a/source/libs/sim/queries/SceneQueries.h
+++ b/source/libs/sim/queries/SceneQueries.h
@@ -1,0 +1,37 @@
+#ifndef SCENEQUERIES_H
+#define SCENEQUERIES_H
+
+#include <glm/vec3.hpp>
+#include <cstdint>
+#include <vector>
+#include <uuid.h>
+
+class ObjectManager;
+
+// Analytic scene queries (raycast, sphere overlap) over the collider geometry. Lives in sim because it
+// is query *behavior* over the data (the data/systems split), but scripting can't link sim — so the
+// server app injects these two statics into BindingContext as function pointers at startup. The
+// signatures below therefore use only types both sim and scripting can see (data + glm + uuid) and must
+// stay matched to BindingContext::RaycastFn / OverlapSphereFn.
+class SceneQueries {
+public:
+  // Cast a ray (origin + normalized direction is computed internally) against every collider whose layer
+  // is in layerMask. Returns true on the nearest hit within maxDistance, writing the outputs only then.
+  // ignoreObject (nil = none) is skipped, so a caster can exclude its own collider. A ray that starts
+  // inside a collider reports it at contact (distance 0).
+  static bool raycast(ObjectManager& objectManager,
+                      const glm::vec3& origin, const glm::vec3& direction, float maxDistance,
+                      uint32_t layerMask, const uuids::uuid& ignoreObject,
+                      uuids::uuid& hitObject, glm::vec3& hitPoint, glm::vec3& hitNormal, float& hitDistance);
+
+  // Collect the uuid of every object whose collider overlaps the sphere and whose layer is in layerMask.
+  // ignoreObject (nil = none) is skipped.
+  static void overlapSphere(ObjectManager& objectManager,
+                            const glm::vec3& center, float radius, uint32_t layerMask,
+                            const uuids::uuid& ignoreObject,
+                            std::vector<uuids::uuid>& results);
+};
+
+
+
+#endif //SCENEQUERIES_H


### PR DESCRIPTION
This pull request introduces several significant improvements to the engine's collision system, focusing on supporting collider triggers and broad-phase collision filtering via layers and masks. It also implements proper event dispatching for collision events and exposes these new features in the editor. The changes are grouped as follows:

**Collision System Improvements:**

* Added support for collider triggers (`isTrigger`) across all collider types, allowing colliders to generate events without physical response. Serialization, deserialization, and network packing/unpacking have been updated accordingly. [[1]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614L73-R76) [[2]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614R92-R96) [[3]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614R163-R165) [[4]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614R174-R176) [[5]](diffhunk://#diff-a8439208174aebddc6460a95eae815d41bef553a983d7b5a2102d3f6501b3126L67-R70) [[6]](diffhunk://#diff-a8439208174aebddc6460a95eae815d41bef553a983d7b5a2102d3f6501b3126R83-R87) [[7]](diffhunk://#diff-a8439208174aebddc6460a95eae815d41bef553a983d7b5a2102d3f6501b3126R118-R130) [[8]](diffhunk://#diff-ae4245524c666d7545cf868c645dc6d377e7201d7e4c949ca1a3ae1f243efbf4R48-R78) [[9]](diffhunk://#diff-fb09b2fb8c56cd4b1d79b3c27041f6c4b3279f2655e50e379526349b9cb16785R35-R50) [[10]](diffhunk://#diff-fb09b2fb8c56cd4b1d79b3c27041f6c4b3279f2655e50e379526349b9cb16785R63-R67)
* Implemented collision layers and masks for colliders, enabling broad-phase filtering so that only colliders with matching layers/masks interact. This is reflected in serialization, deserialization, and network code. [[1]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614L73-R76) [[2]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614R92-R96) [[3]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614R163-R165) [[4]](diffhunk://#diff-8e29ab00545dac1026f71e276fbb620af6ace00d5e2e3d2953258840b86cd614R174-R176) [[5]](diffhunk://#diff-a8439208174aebddc6460a95eae815d41bef553a983d7b5a2102d3f6501b3126L67-R70) [[6]](diffhunk://#diff-a8439208174aebddc6460a95eae815d41bef553a983d7b5a2102d3f6501b3126R83-R87) [[7]](diffhunk://#diff-a8439208174aebddc6460a95eae815d41bef553a983d7b5a2102d3f6501b3126R118-R130) [[8]](diffhunk://#diff-ae4245524c666d7545cf868c645dc6d377e7201d7e4c949ca1a3ae1f243efbf4R48-R78) [[9]](diffhunk://#diff-fb09b2fb8c56cd4b1d79b3c27041f6c4b3279f2655e50e379526349b9cb16785R35-R50) [[10]](diffhunk://#diff-fb09b2fb8c56cd4b1d79b3c27041f6c4b3279f2655e50e379526349b9cb16785R63-R67)

**Collision Event Dispatch and Scene Management:**

* Added a mechanism in `ServerApp` to dispatch collision events (enter/stay/exit) from the simulation to scripts, ensuring that events are delivered as plain data and that the simulation and scripting systems remain decoupled. [[1]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR186-R218) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L111-R124) [[3]](diffhunk://#diff-59a6facf8f8f4ca802ec9e46466dd86b4d1fc813aeaea6dfbce95fae1f4f9292R74-R77)
* Ensured collision contact history is reset when loading/changing scenes or projects, preventing stale collision events from being sent after a scene swap or reset. [[1]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR372-R374) [[2]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR476-R479) [[3]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR492) [[4]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR536-R538)

**Editor Integration:**

* Enhanced the collider editor UI to allow editing of the `isTrigger` property and to provide an intuitive interface for setting collider layers and masks, including a summary and checklist popup for mask selection. [[1]](diffhunk://#diff-80917381175f15717ef83e29934187b3a86efb6a88e8b3fa4928daac2f4641a7R4-R150) [[2]](diffhunk://#diff-80917381175f15717ef83e29934187b3a86efb6a88e8b3fa4928daac2f4641a7R174-R182) [[3]](diffhunk://#diff-80917381175f15717ef83e29934187b3a86efb6a88e8b3fa4928daac2f4641a7R229-R237)

**System Architecture and Code Organization:**

* Established conventions for simulation-to-scripting communication, including function-pointer injection for queries and plain data for events, and documented these in `AGENTS.md`. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L111-R124) [[2]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR16) [[3]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR46-R50)
* Updated includes and forward declarations to support the new features. [[1]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR16) [[2]](diffhunk://#diff-59a6facf8f8f4ca802ec9e46466dd86b4d1fc813aeaea6dfbce95fae1f4f9292R18) [[3]](diffhunk://#diff-aa660f289f813e6a62c6a5e8d293da4621f9687803a66c0d9e196fb183a30236R2)

These changes collectively improve the flexibility, safety, and usability of the collision and scripting systems, and provide a solid foundation for advanced gameplay and editor features.