### PR TITLE
Enhance networking with per-connection senderId and input routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,17 @@ mirrored by a C# `[StructLayout(Sequential)]` struct and registered through `Bri
 the **end** of both to keep the layout matched). `BindingContext` is the bridge from the static, C-ABI
 bindings back to the server's live scene: `ScriptSystem` points it at the current `ObjectManager` each
 tick. The headless server has no GLFW window, so input is networked: clients send `inputState`, the
-server writes it into the global `InputState`, and `InputUtilsBindings` reads it back for scripts. Forces
+server writes it into `InputState`, and `InputUtilsBindings` reads it back for scripts. Input is
+**per-player**: the transport tags each inbound message with a stable connection id (`NetServer::poll`'s
+`senderId`, from a monotonic id the C# backends assign); `ServerApp` binds each connection to a **player
+slot** on join (freed on disconnect via a transport disconnect callback + `NetServer::takeDisconnected`),
+and `InputState` is keyed by that slot. A script reads *its own* player through `ScriptBase.input`
+(`PlayerInput`), which resolves `object → PlayerController.playerSlot → InputState[slot]`; the global
+`InputUtils` stays a player-agnostic aggregate. `PlayerController` is an ordinary replicated data
+component (slot is editable + serialized), so possession is visible to the editor and to clients — the
+hook Phase 4's camera uses to pick "whose view". Mouse delta/scroll and key edges
+(`wasPressedThisTick`) accumulate between fixed ticks and are reset per tick by
+`InputState::clearMouseDeltas()`/`commitInputEdges()`. Forces
 requested from a script are buffered on the `RigidBody` data (pending-force queue) and drained by
 `PhysicsSystem`, keeping `scripting` independent of `sim`. Four conventions worth inheriting: (1) reaching
 another object's component is a **`tryGet`** (`World.tryGetTransform(uuid, out t)` → false when

--- a/source/apps/client/ClientApp.cpp
+++ b/source/apps/client/ClientApp.cpp
@@ -84,13 +84,29 @@ void ClientApp::sendInput()
 {
   const auto snapshot = input::capture(*m_renderer);
 
-  if (m_inputSent && snapshot.keys == m_lastInputKeys && snapshot.focused == m_lastInputFocused)
+  // Discrete state we de-dup on (don't resend an unchanged keyboard/button/cursor every frame). Cursor
+  // position is included so mouse movement triggers a send; delta rides along in the same message.
+  const bool discreteChanged = !m_inputSent
+    || snapshot.keys != m_lastInputKeys
+    || snapshot.focused != m_lastInputFocused
+    || snapshot.buttons != m_lastButtons
+    || snapshot.mouseX != m_lastMouseX
+    || snapshot.mouseY != m_lastMouseY;
+
+  // Scroll is a per-frame amount with no resting position, so it must be sent on any frame it's non-zero
+  // (it isn't captured by the position comparison above).
+  const bool scrolled = snapshot.scrollY != 0.0f;
+
+  if (m_inputSent && !discreteChanged && !scrolled)
   {
     return;
   }
 
   m_lastInputKeys = snapshot.keys;
   m_lastInputFocused = snapshot.focused;
+  m_lastButtons = snapshot.buttons;
+  m_lastMouseX = snapshot.mouseX;
+  m_lastMouseY = snapshot.mouseY;
   m_inputSent = true;
 
   net::Message message(net::MessageType::inputState);
@@ -100,6 +116,13 @@ void ClientApp::sendInput()
   {
     message.write(key);
   }
+
+  message.write(snapshot.mouseX);
+  message.write(snapshot.mouseY);
+  message.write(snapshot.mouseDeltaX);
+  message.write(snapshot.mouseDeltaY);
+  message.write(snapshot.scrollY);
+  message.write(snapshot.buttons);
 
   m_netClient->send(message);
 }

--- a/source/apps/client/ClientApp.h
+++ b/source/apps/client/ClientApp.h
@@ -2,6 +2,7 @@
 #define CLIENTAPP_H
 
 #include <Protocol.h>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -62,6 +63,9 @@ private:
   // clobber this one's keys on the shared server-side InputState every frame.
   std::vector<int> m_lastInputKeys;
   bool m_lastInputFocused = false;
+  uint8_t m_lastButtons = 0;
+  float m_lastMouseX = 0.0f;
+  float m_lastMouseY = 0.0f;
   bool m_inputSent = false;
 
   void createRenderer();

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -250,22 +250,45 @@ void EditorApp::handlePicking()
 
 void EditorApp::sendInput()
 {
-  // Don't let typing in an editor panel drive the player: when ImGui wants the keyboard, report no
-  // keys. focused stays true (an unfocused window already reports no keys), so this view never disables
-  // another connected view's input on the shared server-side InputState.
-  input::InputSnapshot snapshot;
-  if (!ImGui::GetIO().WantCaptureKeyboard)
+  const auto& io = ImGui::GetIO();
+
+  // Don't let editor UI interaction drive the game: when ImGui wants the keyboard, report no keys; when
+  // it wants the mouse (hovering a panel), report no mouse. focused stays true (an unfocused window
+  // already reports no keys), so this view never disables another connected view's input.
+  input::InputSnapshot snapshot = input::capture(*m_renderer);
+
+  if (io.WantCaptureKeyboard)
   {
-    snapshot = input::capture(*m_renderer);
+    snapshot.keys.clear();
   }
 
-  if (m_inputSent && snapshot.keys == m_lastInputKeys && snapshot.focused == m_lastInputFocused)
+  if (io.WantCaptureMouse)
+  {
+    snapshot.mouseDeltaX = 0.0f;
+    snapshot.mouseDeltaY = 0.0f;
+    snapshot.scrollY = 0.0f;
+    snapshot.buttons = 0;
+  }
+
+  const bool discreteChanged = !m_inputSent
+    || snapshot.keys != m_lastInputKeys
+    || snapshot.focused != m_lastInputFocused
+    || snapshot.buttons != m_lastButtons
+    || snapshot.mouseX != m_lastMouseX
+    || snapshot.mouseY != m_lastMouseY;
+
+  const bool scrolled = snapshot.scrollY != 0.0f;
+
+  if (m_inputSent && !discreteChanged && !scrolled)
   {
     return;
   }
 
   m_lastInputKeys = snapshot.keys;
   m_lastInputFocused = snapshot.focused;
+  m_lastButtons = snapshot.buttons;
+  m_lastMouseX = snapshot.mouseX;
+  m_lastMouseY = snapshot.mouseY;
   m_inputSent = true;
 
   net::Message message(net::MessageType::inputState);
@@ -275,6 +298,13 @@ void EditorApp::sendInput()
   {
     message.write(key);
   }
+
+  message.write(snapshot.mouseX);
+  message.write(snapshot.mouseY);
+  message.write(snapshot.mouseDeltaX);
+  message.write(snapshot.mouseDeltaY);
+  message.write(snapshot.scrollY);
+  message.write(snapshot.buttons);
 
   m_netClient->send(message);
 }

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -24,6 +24,7 @@
 #include <components/LightRendererEditor.h>
 #include <components/ColliderEditor.h>
 #include <components/ScriptEditor.h>
+#include <components/PlayerControllerEditor.h>
 #include <NetClient.h>
 #include <ServerProcess.h>
 #include <ManagedHost.h>
@@ -316,6 +317,7 @@ void EditorApp::registerEditors() const
   registerLightRendererEditor(*m_componentEditor);
   registerColliderEditors(*m_componentEditor);
   registerScriptEditor(*m_componentEditor);
+  registerPlayerControllerEditor(*m_componentEditor);
 }
 
 void EditorApp::setupKeybinds()

--- a/source/apps/editor/EditorApp.h
+++ b/source/apps/editor/EditorApp.h
@@ -4,6 +4,7 @@
 #include <VulkanEngine/components/window/Window.h>
 #include <Protocol.h>
 #include <scenes/SceneManager.h>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -97,6 +98,9 @@ private:
   // focused client's keys on the shared server-side InputState.
   std::vector<int> m_lastInputKeys;
   bool m_lastInputFocused = false;
+  uint8_t m_lastButtons = 0;
+  float m_lastMouseX = 0.0f;
+  float m_lastMouseY = 0.0f;
   bool m_inputSent = false;
 
   // Edge-detect the mouse so viewport picking only fires on a fresh Ctrl+click.

--- a/source/apps/server/DefaultProject.cpp
+++ b/source/apps/server/DefaultProject.cpp
@@ -91,6 +91,14 @@ json sphereCollider()
   };
 }
 
+json playerController(const int slot = 0)
+{
+  return {
+    { "type", "PlayerController" },
+    { "playerSlot", slot }
+  };
+}
+
 json makeObject(const std::string& name, json components, json scripts = json::array())
 {
   return {
@@ -137,13 +145,14 @@ json sphere(const glm::vec3& position, const glm::vec3& scale = glm::vec3(1))
   }));
 }
 
-json player(const glm::vec3& position)
+json player(const glm::vec3& position, const int slot = 0)
 {
   return makeObject("Player", json::array({
     transform(position),
     modelRenderer(playerModel, whiteTexture, whiteTexture),
     rigidBody(),
-    sphereCollider()
+    sphereCollider(),
+    playerController(slot)
   }), json::array({
     {
       { "type", "Script" },

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -151,9 +151,11 @@ void ServerApp::run()
     {
       fixedUpdate(m_fixedUpdateDt);
 
-      // The tick's scripts have now read this tick's mouse motion; zero the accumulated delta/scroll so a
-      // still mouse reads zero next tick (and a catch-up sub-step doesn't re-consume the same movement).
+      // The tick's scripts have now read this tick's mouse motion + key edges; zero the accumulated
+      // delta/scroll and snapshot the current keys as "last tick's" so a still mouse reads zero next tick
+      // and wasPressed/ReleasedThisTick reflect only genuinely new changes (a catch-up sub-step sees none).
       InputState::clearMouseDeltas();
+      InputState::commitInputEdges();
 
       m_timeAccumulator -= m_fixedUpdateDt;
       ++steps;

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -132,6 +132,13 @@ void ServerApp::run()
       }
     }
 
+    // Release the player slot of any connection that dropped, so a departed player's input doesn't linger
+    // and its slot is free for the next joiner.
+    for (const auto connId : m_netServer->takeDisconnected())
+    {
+      handleDisconnect(connId);
+    }
+
     const auto now = std::chrono::steady_clock::now();
     const float dt = std::chrono::duration<float>(now - m_previousTime).count();
     m_previousTime = now;
@@ -248,7 +255,7 @@ void ServerApp::handleClientMessage(const net::Message& message, const int32_t s
   switch (message.getType())
   {
     case net::MessageType::join:
-      handleJoin(message);
+      handleJoin(message, senderId);
       break;
 
     case net::MessageType::editComponent:
@@ -279,14 +286,60 @@ void ServerApp::handleClientMessage(const net::Message& message, const int32_t s
   }
 }
 
-void ServerApp::handleJoin(const net::Message& message)
+void ServerApp::handleJoin(const net::Message& message, const int32_t senderId)
 {
-  // A client joined: tell it whether this server is editable, then send the full project/scene as a
-  // Snapshot. Record that a connection has been seen so an ephemeral server (exitWhenEmpty) can
-  // later exit when the last one drops.
+  // A client joined: bind it to a player slot (so its input routes to that player), tell it whether this
+  // server is editable, then send the full project/scene as a Snapshot. Record that a connection has been
+  // seen so an ephemeral server (exitWhenEmpty) can later exit when the last one drops.
   m_hasConnected = true;
+  assignPlayerSlot(senderId);
   broadcastEditStatus();
   broadcastSnapshot();
+}
+
+int32_t ServerApp::assignPlayerSlot(const int32_t connId)
+{
+  if (const auto it = m_connectionSlots.find(connId); it != m_connectionSlots.end())
+  {
+    return it->second;
+  }
+
+  // Lowest free slot: scan upward until a slot no connection currently holds is found.
+  int32_t slot = 0;
+  const auto slotTaken = [this](const int32_t candidate) {
+    for (const auto& [conn, taken] : m_connectionSlots)
+    {
+      if (taken == candidate)
+      {
+        return true;
+      }
+    }
+    return false;
+  };
+  while (slotTaken(slot))
+  {
+    ++slot;
+  }
+
+  m_connectionSlots.emplace(connId, slot);
+  logMessage("Info", "Bound connection " + std::to_string(connId) + " to player slot " + std::to_string(slot) + ".");
+  return slot;
+}
+
+void ServerApp::handleDisconnect(const int32_t connId)
+{
+  const auto it = m_connectionSlots.find(connId);
+  if (it == m_connectionSlots.end())
+  {
+    return;
+  }
+
+  const int32_t slot = it->second;
+  m_connectionSlots.erase(it);
+  InputState::removeSlot(slot);
+
+  logMessage("Info", "Connection " + std::to_string(connId) + " dropped; freed player slot "
+    + std::to_string(slot) + ".");
 }
 
 void ServerApp::handleEditComponent(const net::Message& message) const
@@ -413,11 +466,15 @@ void ServerApp::handleAddAsset(const net::Message& message) const
 
 void ServerApp::handleInputState(const net::Message& message, const int32_t senderId)
 {
-  // The client's captured keyboard state for this frame; the scripts' InputUtils bindings read it. It
-  // lands in this connection's own slot (keyed by senderId) so two players don't clobber each other.
+  // The client's captured keyboard state for this frame; the scripts read it through their player's slot.
+  // It lands in this connection's player slot so two players don't clobber each other. assignPlayerSlot is
+  // idempotent — normally the slot already exists from the join, but bind on demand in case input somehow
+  // arrives first.
+  const int32_t slot = assignPlayerSlot(senderId);
+
   net::MessageReader reader(message);
   const auto focused = reader.read<bool>();
-  InputState::setFocused(senderId, focused);
+  InputState::setFocused(slot, focused);
 
   const auto numKeys = reader.read<size_t>();
   std::vector<int> keysPressed(numKeys);
@@ -426,7 +483,7 @@ void ServerApp::handleInputState(const net::Message& message, const int32_t send
     key = reader.read<int>();
   }
 
-  InputState::setKeysPressed(senderId, keysPressed);
+  InputState::setKeysPressed(slot, keysPressed);
 }
 
 void ServerApp::handleSceneControl(const net::Message& message) const

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -151,6 +151,10 @@ void ServerApp::run()
     {
       fixedUpdate(m_fixedUpdateDt);
 
+      // The tick's scripts have now read this tick's mouse motion; zero the accumulated delta/scroll so a
+      // still mouse reads zero next tick (and a catch-up sub-step doesn't re-consume the same movement).
+      InputState::clearMouseDeltas();
+
       m_timeAccumulator -= m_fixedUpdateDt;
       ++steps;
       ticked = true;
@@ -484,6 +488,20 @@ void ServerApp::handleInputState(const net::Message& message, const int32_t send
   }
 
   InputState::setKeysPressed(slot, keysPressed);
+
+  // Mouse block, appended after the keys (see Protocol.h). Guard on remaining() so an older client that
+  // predates mouse input degrades to "no mouse" instead of throwing an underflow.
+  constexpr size_t mouseBytes = 5 * sizeof(float) + sizeof(uint8_t);
+  if (reader.remaining() >= mouseBytes)
+  {
+    const auto mouseX = reader.read<float>();
+    const auto mouseY = reader.read<float>();
+    const auto mouseDeltaX = reader.read<float>();
+    const auto mouseDeltaY = reader.read<float>();
+    const auto scrollY = reader.read<float>();
+    const auto buttons = reader.read<uint8_t>();
+    InputState::setMouse(slot, mouseX, mouseY, mouseDeltaX, mouseDeltaY, scrollY, buttons);
+  }
 }
 
 void ServerApp::handleSceneControl(const net::Message& message) const

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -117,13 +117,14 @@ void ServerApp::run()
   while (isActive())
   {
     net::Message message;
-    while (m_netServer->poll(message))
+    int32_t senderId = 0;
+    while (m_netServer->poll(message, senderId))
     {
       // A bad/malicious message (or a script-bridge hiccup while building a snapshot) must not take the
       // whole server down - that would look like "client connected, then nothing".
       try
       {
-        handleClientMessage(message);
+        handleClientMessage(message, senderId);
       }
       catch (const std::exception& e)
       {
@@ -235,7 +236,7 @@ namespace {
   }
 }
 
-void ServerApp::handleClientMessage(const net::Message& message)
+void ServerApp::handleClientMessage(const net::Message& message, const int32_t senderId)
 {
   // A non-edit server is read-only: it serves snapshots/deltas to editors that connect to view it, but
   // never applies their edits.
@@ -267,7 +268,7 @@ void ServerApp::handleClientMessage(const net::Message& message)
       break;
 
     case net::MessageType::inputState:
-      handleInputState(message);
+      handleInputState(message, senderId);
       break;
 
     case net::MessageType::sceneControl:
@@ -410,12 +411,13 @@ void ServerApp::handleAddAsset(const net::Message& message) const
   broadcastSnapshot();
 }
 
-void ServerApp::handleInputState(const net::Message& message)
+void ServerApp::handleInputState(const net::Message& message, const int32_t senderId)
 {
-  // The client's captured keyboard state for this frame; the scripts' InputUtils bindings read it.
+  // The client's captured keyboard state for this frame; the scripts' InputUtils bindings read it. It
+  // lands in this connection's own slot (keyed by senderId) so two players don't clobber each other.
   net::MessageReader reader(message);
   const auto focused = reader.read<bool>();
-  InputState::setFocused(focused);
+  InputState::setFocused(senderId, focused);
 
   const auto numKeys = reader.read<size_t>();
   std::vector<int> keysPressed(numKeys);
@@ -424,7 +426,7 @@ void ServerApp::handleInputState(const net::Message& message)
     key = reader.read<int>();
   }
 
-  InputState::setKeysPressed(keysPressed);
+  InputState::setKeysPressed(senderId, keysPressed);
 }
 
 void ServerApp::handleSceneControl(const net::Message& message) const

--- a/source/apps/server/ServerApp.h
+++ b/source/apps/server/ServerApp.h
@@ -4,8 +4,10 @@
 #include <Protocol.h>
 #include <nlohmann/json_fwd.hpp>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 class ManagedHost;
 class ComponentRegistry;
@@ -69,6 +71,18 @@ private:
   // doesn't exit during the launch -> connect window when the count is still 0).
   bool m_hasConnected = false;
 
+  // Player↔connection binding (Phase 3.2): each connection is bound to a player slot (0, 1, ...) on join
+  // and released on disconnect. inputState from a connection is written into its slot; a script reads its
+  // own player's input by resolving its object's PlayerController.playerSlot to that slot. Touched only on
+  // the tick thread (join / inputState / disconnect all run there), so no locking is needed.
+  std::unordered_map<int32_t, int32_t> m_connectionSlots;
+
+  // Bind connId to the lowest free player slot (idempotent — returns the existing slot if already bound).
+  int32_t assignPlayerSlot(int32_t connId);
+
+  // Release a dropped connection's slot and clear its input.
+  void handleDisconnect(int32_t connId);
+
   void fixedUpdate(float dt) const;
 
   // Feed this tick's collision enter/stay/exit pairs (from CollisionSystem) into the scripts. Bridges
@@ -79,7 +93,7 @@ private:
   // messages like inputState land in the right slot.
   void handleClientMessage(const net::Message& message, int32_t senderId);
 
-  void handleJoin(const net::Message& message);
+  void handleJoin(const net::Message& message, int32_t senderId);
 
   void handleEditComponent(const net::Message& message) const;
 
@@ -89,7 +103,7 @@ private:
 
   void handleAddAsset(const net::Message& message) const;
 
-  static void handleInputState(const net::Message& message, int32_t senderId);
+  void handleInputState(const net::Message& message, int32_t senderId);
 
   void handleSceneControl(const net::Message& message) const;
 

--- a/source/apps/server/ServerApp.h
+++ b/source/apps/server/ServerApp.h
@@ -75,7 +75,9 @@ private:
   // sim and scripting at the app level so neither library depends on the other.
   void dispatchCollisionEvents(ObjectManager& objectManager) const;
 
-  void handleClientMessage(const net::Message& message);
+  // senderId is the stable connection id of the message's origin (from NetServer::poll), so per-client
+  // messages like inputState land in the right slot.
+  void handleClientMessage(const net::Message& message, int32_t senderId);
 
   void handleJoin(const net::Message& message);
 
@@ -87,7 +89,7 @@ private:
 
   void handleAddAsset(const net::Message& message) const;
 
-  static void handleInputState(const net::Message& message);
+  static void handleInputState(const net::Message& message, int32_t senderId);
 
   void handleSceneControl(const net::Message& message) const;
 

--- a/source/libs/data/CMakeLists.txt
+++ b/source/libs/data/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(${PROJECT_NAME}
   objects/components/RigidBody.h
   objects/components/Script.cpp
   objects/components/Script.h
+  objects/components/PlayerController.cpp
+  objects/components/PlayerController.h
   objects/components/ModelRenderer.cpp
   objects/components/ModelRenderer.h
   objects/components/LightRenderer.cpp

--- a/source/libs/data/ComponentRegistration.cpp
+++ b/source/libs/data/ComponentRegistration.cpp
@@ -7,6 +7,7 @@
 #include "objects/components/collisions/BoxCollider.h"
 #include "objects/components/collisions/SphereCollider.h"
 #include "objects/components/Script.h"
+#include "objects/components/PlayerController.h"
 #include <memory>
 
 void registerDataComponents(ComponentRegistry& componentRegistry)
@@ -27,4 +28,7 @@ void registerDataComponents(ComponentRegistry& componentRegistry)
   // Script data is just className + a field blob; the live C# instance is attached by ECS3DScripting
   // (server only). loadFromJSON sets the className, so the factory is argless like the rest.
   componentRegistry.registerComponent("Script", [] { return std::make_shared<Script>(); });
+
+  // Player↔object association (Phase 3.2): marks an object as owned by a player slot.
+  componentRegistry.registerComponent("PlayerController", [] { return std::make_shared<PlayerController>(); });
 }

--- a/source/libs/data/objects/components/Component.h
+++ b/source/libs/data/objects/components/Component.h
@@ -22,7 +22,8 @@ enum class ComponentType {
   SubComponentType_none,
   SubComponentType_boxCollider,
   SubComponentType_sphereCollider,
-  script
+  script,
+  playerController // appended last: the packed value is the wire discriminator, so new types go at the end
 };
 
 const std::unordered_map<ComponentType, std::string> componentTypeToString {
@@ -32,7 +33,8 @@ const std::unordered_map<ComponentType, std::string> componentTypeToString {
   {ComponentType::SubComponentType_boxCollider, "Box Collider"},
   {ComponentType::SubComponentType_sphereCollider, "Sphere Collider"},
   {ComponentType::lightRenderer, "Light Renderer"},
-  {ComponentType::script, "Script"}
+  {ComponentType::script, "Script"},
+  {ComponentType::playerController, "Player Controller"}
 };
 
 const std::unordered_map<ComponentType, ComponentType> subComponentTypeToParent {
@@ -50,7 +52,8 @@ const std::unordered_map<ComponentType, std::string> componentTypeToRegistryKey 
   {ComponentType::lightRenderer, "LightRenderer"},
   {ComponentType::SubComponentType_boxCollider, "Box"},
   {ComponentType::SubComponentType_sphereCollider, "Sphere"},
-  {ComponentType::script, "Script"}
+  {ComponentType::script, "Script"},
+  {ComponentType::playerController, "PlayerController"}
 };
 
 class ComponentVariableBase {

--- a/source/libs/data/objects/components/PlayerController.cpp
+++ b/source/libs/data/objects/components/PlayerController.cpp
@@ -1,0 +1,44 @@
+#include "PlayerController.h"
+#include <nlohmann/json.hpp>
+#include <Protocol.h>
+
+PlayerController::PlayerController()
+  : Component(ComponentType::playerController)
+{
+  loadVariable(m_playerSlot);
+}
+
+int32_t PlayerController::getPlayerSlot() const
+{
+  return m_playerSlot.get();
+}
+
+void PlayerController::setPlayerSlot(const int32_t playerSlot)
+{
+  m_playerSlot.set(playerSlot);
+}
+
+nlohmann::json PlayerController::serialize()
+{
+  return {
+    { "type", "PlayerController" },
+    { "playerSlot", m_playerSlot.getInitialValue() }
+  };
+}
+
+void PlayerController::loadFromJSON(const nlohmann::json& componentData)
+{
+  // value(...) so an older scene without the field defaults cleanly (slot 0).
+  m_playerSlot.set(componentData.value("playerSlot", 0));
+}
+
+void PlayerController::pack(net::Message& message) const
+{
+  message.write(ComponentType::playerController);
+  message.write(m_playerSlot.get());
+}
+
+void PlayerController::unpack(net::MessageReader& messageReader)
+{
+  m_playerSlot.set(messageReader.read<int32_t>());
+}

--- a/source/libs/data/objects/components/PlayerController.h
+++ b/source/libs/data/objects/components/PlayerController.h
@@ -1,0 +1,32 @@
+#ifndef PLAYERCONTROLLER_H
+#define PLAYERCONTROLLER_H
+
+#include "Component.h"
+#include <cstdint>
+
+// Marks an object as owned by a player (Phase 3.2). playerSlot is the player index the object belongs
+// to; the server binds each connection to a slot (see ServerApp), so a script on this object reads that
+// player's input via ScriptBase.input. The slot is a ComponentVariable so a script/spawner can rebind it
+// at runtime (a Phase 5 player spawner sets it on a freshly spawned player) and it resets on scene stop.
+class PlayerController final : public Component {
+public:
+  PlayerController();
+
+  [[nodiscard]] int32_t getPlayerSlot() const;
+  void setPlayerSlot(int32_t playerSlot);
+
+  [[nodiscard]] nlohmann::json serialize() override;
+
+  void loadFromJSON(const nlohmann::json& componentData) override;
+
+  void pack(net::Message& message) const override;
+
+  void unpack(net::MessageReader& messageReader) override;
+
+private:
+  ComponentVariable<int32_t> m_playerSlot{0};
+};
+
+
+
+#endif //PLAYERCONTROLLER_H

--- a/source/libs/editor/CMakeLists.txt
+++ b/source/libs/editor/CMakeLists.txt
@@ -24,6 +24,8 @@ add_library(${PROJECT_NAME}
   components/ColliderEditor.h
   components/ScriptEditor.cpp
   components/ScriptEditor.h
+  components/PlayerControllerEditor.cpp
+  components/PlayerControllerEditor.h
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/source/libs/editor/ObjectGUIManager.cpp
+++ b/source/libs/editor/ObjectGUIManager.cpp
@@ -18,12 +18,13 @@ namespace {
   // checkType is the ComponentType whose presence on the object hides this entry.
   // Transform is omitted (every object already has one); scripts attach via drag & drop only.
   struct AddableComponent { const char* label; const char* key; ComponentType checkType; gc::SecIcon icon; };
-  constexpr std::array<AddableComponent, 5> addableComponents {{
-    { "Rigid Body",      "RigidBody",     ComponentType::rigidBody,     gc::SecIcon::rigid    },
-    { "Model Renderer",  "ModelRenderer", ComponentType::modelRenderer, gc::SecIcon::image    },
-    { "Light Renderer",  "LightRenderer", ComponentType::lightRenderer, gc::SecIcon::light    },
-    { "Box Collider",    "Box",           ComponentType::collider,      gc::SecIcon::collider },
-    { "Sphere Collider", "Sphere",        ComponentType::collider,      gc::SecIcon::sphere   }
+  constexpr std::array<AddableComponent, 6> addableComponents {{
+    { "Rigid Body",        "RigidBody",        ComponentType::rigidBody,        gc::SecIcon::rigid    },
+    { "Model Renderer",    "ModelRenderer",    ComponentType::modelRenderer,    gc::SecIcon::image    },
+    { "Light Renderer",    "LightRenderer",    ComponentType::lightRenderer,    gc::SecIcon::light    },
+    { "Box Collider",      "Box",              ComponentType::collider,         gc::SecIcon::collider },
+    { "Sphere Collider",   "Sphere",           ComponentType::collider,         gc::SecIcon::sphere   },
+    { "Player Controller", "PlayerController", ComponentType::playerController, gc::SecIcon::none     }
   }};
 
   // Heuristic icon for an object derived from its components (the mockup shows a per-object glyph).

--- a/source/libs/editor/components/PlayerControllerEditor.cpp
+++ b/source/libs/editor/components/PlayerControllerEditor.cpp
@@ -1,0 +1,63 @@
+#include "PlayerControllerEditor.h"
+#include "../ComponentEditor.h"
+#include "../GuiComponents.h"
+#include <objects/components/PlayerController.h>
+#include <imgui.h>
+#include <algorithm>
+#include <memory>
+
+void registerPlayerControllerEditor(ComponentEditor& componentEditor)
+{
+  // Keyed by the componentTypeToString display name (what ObjectGUIManager looks the handler up by).
+  componentEditor.registerHandler("Player Controller", [](const std::shared_ptr<Component>& component) -> bool {
+    const auto playerController = std::dynamic_pointer_cast<PlayerController>(component);
+    if (!playerController)
+    {
+      return false;
+    }
+
+    bool edited = false;
+
+    if (ComponentEditor::displayHeader(component))
+    {
+      // The player index this object belongs to. The server binds each connection to a slot; a script on
+      // this object reads that player's input. A drag field flanked by -/+ steppers, mirroring the
+      // collider Layer control.
+      int slot = playerController->getPlayerSlot();
+      bool slotEdited = false;
+
+      gc::rowLabel("Player Slot");
+      ImGui::PushID("PlayerSlot");
+      const float step = ImGui::GetFrameHeight();
+      const float spacing = ImGui::GetStyle().ItemSpacing.x;
+      const float dragWidth = ImGui::GetContentRegionAvail().x - 2.0f * (step + spacing);
+
+      if (ImGui::Button("-", ImVec2(step, step)) && slot > 0)
+      {
+        --slot;
+        slotEdited = true;
+      }
+      ImGui::SameLine();
+      ImGui::SetNextItemWidth(dragWidth);
+      if (ImGui::DragInt("##playerSlot", &slot, 0.1f, 0, 255))
+      {
+        slotEdited = true;
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("+", ImVec2(step, step)))
+      {
+        ++slot;
+        slotEdited = true;
+      }
+      ImGui::PopID();
+
+      if (slotEdited)
+      {
+        playerController->setPlayerSlot(std::max(slot, 0));
+        edited = true;
+      }
+    }
+
+    return edited;
+  });
+}

--- a/source/libs/editor/components/PlayerControllerEditor.h
+++ b/source/libs/editor/components/PlayerControllerEditor.h
@@ -1,0 +1,10 @@
+#ifndef PLAYERCONTROLLEREDITOR_H
+#define PLAYERCONTROLLEREDITOR_H
+
+class ComponentEditor;
+
+void registerPlayerControllerEditor(ComponentEditor& componentEditor);
+
+
+
+#endif //PLAYERCONTROLLEREDITOR_H

--- a/source/libs/net/MessageQueue.cpp
+++ b/source/libs/net/MessageQueue.cpp
@@ -2,16 +2,16 @@
 
 namespace net {
 
-void MessageQueue::push(Message message)
+void MessageQueue::push(Message message, const int32_t senderId)
 {
   // The websocket runs on its own thread, so the inbox/outbox are guarded. This is the
   // thread-safety wrinkle that synchronous script calls don't have.
   std::lock_guard lock(m_mutex);
 
-  m_messages.push(std::move(message));
+  m_messages.push(Entry{ std::move(message), senderId });
 }
 
-bool MessageQueue::pop(Message& message)
+bool MessageQueue::pop(Message& message, int32_t& senderId)
 {
   std::lock_guard lock(m_mutex);
 
@@ -20,7 +20,8 @@ bool MessageQueue::pop(Message& message)
     return false;
   }
 
-  message = std::move(m_messages.front());
+  message = std::move(m_messages.front().message);
+  senderId = m_messages.front().senderId;
   m_messages.pop();
 
   return true;

--- a/source/libs/net/MessageQueue.h
+++ b/source/libs/net/MessageQueue.h
@@ -2,6 +2,7 @@
 #define MESSAGEQUEUE_H
 
 #include <Protocol.h>
+#include <cstdint>
 #include <mutex>
 #include <queue>
 
@@ -9,14 +10,21 @@ namespace net {
 
 class MessageQueue {
 public:
-  void push(Message message);
+  // senderId is the stable connection id of the message's origin (server inbox); it is 0 where there is
+  // no distinct sender (the client inbox has a single peer).
+  void push(Message message, int32_t senderId = 0);
 
-  [[nodiscard]] bool pop(Message& message);
+  [[nodiscard]] bool pop(Message& message, int32_t& senderId);
 
 private:
+  struct Entry {
+    Message message;
+    int32_t senderId = 0;
+  };
+
   std::mutex m_mutex;
 
-  std::queue<Message> m_messages;
+  std::queue<Entry> m_messages;
 };
 
 }

--- a/source/libs/net/NetClient.cpp
+++ b/source/libs/net/NetClient.cpp
@@ -87,7 +87,9 @@ void NetClient::send(const Message& message) const
 
 bool NetClient::poll(Message& message)
 {
-  return m_inbox.pop(message);
+  // The client has a single peer (the server), so the sender id is meaningless here — discard it.
+  int32_t senderId = 0;
+  return m_inbox.pop(message, senderId);
 }
 
 void NetClient::enqueue(const uint8_t type, const uint8_t* data, const int32_t len)
@@ -97,11 +99,6 @@ void NetClient::enqueue(const uint8_t type, const uint8_t* data, const int32_t l
   {
     message.write(chunk);
   }
-
-  // Message message {
-  //   .type = static_cast<MessageType>(type),
-  //   .payload = std::vector<uint8_t>(data, data + len)
-  // };
 
   m_inbox.push(std::move(message));
 }

--- a/source/libs/net/NetServer.cpp
+++ b/source/libs/net/NetServer.cpp
@@ -1,6 +1,7 @@
 #include "NetServer.h"
 #include <ManagedHost.h>
 #include <array>
+#include <utility>
 
 namespace net {
 
@@ -27,6 +28,14 @@ extern "C" void ecs3dNetServerReceive(const int32_t connId, const uint8_t type, 
   }
 }
 
+extern "C" void ecs3dNetServerDisconnect(const int32_t connId)
+{
+  if (g_activeServer)
+  {
+    g_activeServer->enqueueDisconnect(connId);
+  }
+}
+
 NetServer::NetServer(std::shared_ptr<ManagedHost> host)
   : m_host(std::move(host))
 {}
@@ -47,9 +56,11 @@ void NetServer::start(const int port, const bool editMode, const std::string& au
   m_broadcastFn = m_host->getDelegate(kAssembly, kType, "serverBroadcast");
   m_connectionCountFn = m_host->getDelegate(kAssembly, kType, "serverConnectionCount");
   m_setCallbackFn = m_host->getDelegate(kAssembly, kType, "serverSetReceiveCallback");
+  m_setDisconnectCallbackFn = m_host->getDelegate(kAssembly, kType, "serverSetDisconnectCallback");
 
   g_activeServer = this;
   reinterpret_cast<SetCallbackFn>(m_setCallbackFn)(reinterpret_cast<void*>(&ecs3dNetServerReceive));
+  reinterpret_cast<SetCallbackFn>(m_setDisconnectCallbackFn)(reinterpret_cast<void*>(&ecs3dNetServerDisconnect));
 
   reinterpret_cast<ServerStartFn>(m_startFn)(static_cast<int32_t>(port), m_editMode ? 1 : 0, authToken.c_str());
   m_started = true;
@@ -107,6 +118,18 @@ void NetServer::enqueue(const int32_t connId, const uint8_t type, const uint8_t*
   }
 
   m_inbox.push(std::move(message), connId);
+}
+
+void NetServer::enqueueDisconnect(const int32_t connId)
+{
+  std::lock_guard lock(m_disconnectMutex);
+  m_disconnected.push_back(connId);
+}
+
+std::vector<int32_t> NetServer::takeDisconnected()
+{
+  std::lock_guard lock(m_disconnectMutex);
+  return std::exchange(m_disconnected, {});
 }
 
 }

--- a/source/libs/net/NetServer.cpp
+++ b/source/libs/net/NetServer.cpp
@@ -19,11 +19,11 @@ namespace {
   NetServer* g_activeServer = nullptr;
 }
 
-extern "C" void ecs3dNetServerReceive(const uint8_t type, const uint8_t* data, const int32_t len)
+extern "C" void ecs3dNetServerReceive(const int32_t connId, const uint8_t type, const uint8_t* data, const int32_t len)
 {
   if (g_activeServer)
   {
-    g_activeServer->enqueue(type, data, len);
+    g_activeServer->enqueue(connId, type, data, len);
   }
 }
 
@@ -93,12 +93,12 @@ int NetServer::connectionCount() const
   return reinterpret_cast<ServerConnectionCountFn>(m_connectionCountFn)();
 }
 
-bool NetServer::poll(Message& message)
+bool NetServer::poll(Message& message, int32_t& senderId)
 {
-  return m_inbox.pop(message);
+  return m_inbox.pop(message, senderId);
 }
 
-void NetServer::enqueue(const uint8_t type, const uint8_t* data, const int32_t len)
+void NetServer::enqueue(const int32_t connId, const uint8_t type, const uint8_t* data, const int32_t len)
 {
   Message message(static_cast<MessageType>(type));
   for (const std::vector<uint8_t> chunks(data, data + len); const auto& chunk : chunks)
@@ -106,12 +106,7 @@ void NetServer::enqueue(const uint8_t type, const uint8_t* data, const int32_t l
     message.write(chunk);
   }
 
-  // Message message {
-  //   .type = static_cast<MessageType>(type),
-  //   .payload = std::vector<uint8_t>(data, data + len)
-  // };
-
-  m_inbox.push(std::move(message));
+  m_inbox.push(std::move(message), connId);
 }
 
 }

--- a/source/libs/net/NetServer.h
+++ b/source/libs/net/NetServer.h
@@ -26,11 +26,14 @@ public:
   // spawned) server to detect when its last connection drops; returns 0 before start().
   [[nodiscard]] int connectionCount() const;
 
-  [[nodiscard]] bool poll(Message& message);
+  // senderId is set to the stable connection id of the message's origin, so the app can route input to
+  // the right per-connection slot.
+  [[nodiscard]] bool poll(Message& message, int32_t& senderId);
 
   // Called from the C# socket thread (via the registered native callback) to hand an inbound message
-  // to the tick thread; the inbox is mutex-protected so the threads never collide.
-  void enqueue(uint8_t type, const uint8_t* data, int32_t len);
+  // to the tick thread; the inbox is mutex-protected so the threads never collide. connId is the stable
+  // per-connection id the transport assigns each client.
+  void enqueue(int32_t connId, uint8_t type, const uint8_t* data, int32_t len);
 
 private:
   std::shared_ptr<ManagedHost> m_host;

--- a/source/libs/net/NetServer.h
+++ b/source/libs/net/NetServer.h
@@ -4,7 +4,9 @@
 #include "MessageQueue.h"
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <vector>
 
 class ManagedHost;
 
@@ -35,10 +37,21 @@ public:
   // per-connection id the transport assigns each client.
   void enqueue(int32_t connId, uint8_t type, const uint8_t* data, int32_t len);
 
+  // Called from the C# socket thread when a connection drops; the connId is buffered for the tick thread
+  // to drain via takeDisconnected() so it can release the player slot bound to that connection.
+  void enqueueDisconnect(int32_t connId);
+
+  // Drain the connection ids that have dropped since the last call (clears the buffer).
+  [[nodiscard]] std::vector<int32_t> takeDisconnected();
+
 private:
   std::shared_ptr<ManagedHost> m_host;
 
   MessageQueue m_inbox;
+
+  // Dropped connection ids pushed from the socket threads, drained on the tick thread.
+  std::mutex m_disconnectMutex;
+  std::vector<int32_t> m_disconnected;
 
   bool m_editMode = false;
   bool m_started = false;
@@ -49,6 +62,7 @@ private:
   void* m_broadcastFn = nullptr;
   void* m_connectionCountFn = nullptr;
   void* m_setCallbackFn = nullptr;
+  void* m_setDisconnectCallbackFn = nullptr;
 };
 
 }

--- a/source/libs/net/Transport/TcpBackend.cs
+++ b/source/libs/net/Transport/TcpBackend.cs
@@ -24,6 +24,10 @@ internal sealed class TcpBackend : TransportBackend
   private readonly List<TcpClient> _clients = new();
   private readonly object _clientsLock = new();
 
+  // A stable, monotonically-increasing id handed to each accepted connection, surfaced to C++ on every
+  // inbound message so the server can keep per-client state (e.g. input). Never reused within a run.
+  private int _nextConnId;
+
   // -- Client --
   private TcpClient? _client;
   private Thread? _clientThread;
@@ -113,12 +117,14 @@ internal sealed class TcpBackend : TransportBackend
 
       client.NoDelay = true;
 
+      var connId = Interlocked.Increment(ref _nextConnId);
+
       lock (_clientsLock)
       {
         _clients.Add(client);
       }
 
-      var thread = new Thread(() => ServerReceiveLoop(client))
+      var thread = new Thread(() => ServerReceiveLoop(client, connId))
       {
         IsBackground = true,
         Name = "ecs3d-net-client"
@@ -127,7 +133,7 @@ internal sealed class TcpBackend : TransportBackend
     }
   }
 
-  private void ServerReceiveLoop(TcpClient client)
+  private void ServerReceiveLoop(TcpClient client, int connId)
   {
     try
     {
@@ -145,7 +151,7 @@ internal sealed class TcpBackend : TransportBackend
             break;
           }
 
-          Transport.DeliverServer(type, payload);
+          Transport.DeliverServer(connId, type, payload);
         }
       }
       else

--- a/source/libs/net/Transport/TcpBackend.cs
+++ b/source/libs/net/Transport/TcpBackend.cs
@@ -170,6 +170,10 @@ internal sealed class TcpBackend : TransportBackend
     }
 
     try { client.Close(); } catch { /* ignore */ }
+
+    // Let the server release any player slot bound to this connection. A no-op on the C++ side if the
+    // connection never joined (e.g. a rejected handshake), since it holds no slot for it.
+    Transport.DeliverServerDisconnect(connId);
   }
 
   public override byte ClientConnect(string host, int port, byte role, string token)

--- a/source/libs/net/Transport/Transport.cs
+++ b/source/libs/net/Transport/Transport.cs
@@ -22,6 +22,10 @@ public static unsafe class Transport
   private static delegate* unmanaged<int, byte, byte*, int, void> _serverReceive;
   private static delegate* unmanaged<byte, byte*, int, void> _clientReceive;
 
+  // Fired when a server-side connection drops, carrying its connection id, so the C++ side can release
+  // the player slot bound to it. Optional — the C++ side may never register one.
+  private static delegate* unmanaged<int, void> _serverDisconnect;
+
   private static readonly TransportBackend _backend = CreateBackend();
 
   private static TransportBackend CreateBackend()
@@ -38,6 +42,12 @@ public static unsafe class Transport
   public static void serverSetReceiveCallback(IntPtr fn)
   {
     _serverReceive = (delegate* unmanaged<int, byte, byte*, int, void>)fn;
+  }
+
+  [UnmanagedCallersOnly]
+  public static void serverSetDisconnectCallback(IntPtr fn)
+  {
+    _serverDisconnect = (delegate* unmanaged<int, void>)fn;
   }
 
   [UnmanagedCallersOnly]
@@ -111,6 +121,15 @@ public static unsafe class Transport
     fixed (byte* p = payload)
     {
       callback(connId, type, p, payload.Length);
+    }
+  }
+
+  internal static void DeliverServerDisconnect(int connId)
+  {
+    var callback = _serverDisconnect;
+    if (callback != null)
+    {
+      callback(connId);
     }
   }
 

--- a/source/libs/net/Transport/Transport.cs
+++ b/source/libs/net/Transport/Transport.cs
@@ -17,7 +17,9 @@ public static unsafe class Transport
 //   private static readonly TransportProtocol Protocol = TransportProtocol.WebSocket;
   private static readonly TransportProtocol Protocol = TransportProtocol.Tcp;
 
-  private static delegate* unmanaged<byte, byte*, int, void> _serverReceive;
+  // The server callback carries the origin connection id (the C++ side routes per-client input by it);
+  // the client callback has a single peer and needs none.
+  private static delegate* unmanaged<int, byte, byte*, int, void> _serverReceive;
   private static delegate* unmanaged<byte, byte*, int, void> _clientReceive;
 
   private static readonly TransportBackend _backend = CreateBackend();
@@ -35,7 +37,7 @@ public static unsafe class Transport
   [UnmanagedCallersOnly]
   public static void serverSetReceiveCallback(IntPtr fn)
   {
-    _serverReceive = (delegate* unmanaged<byte, byte*, int, void>)fn;
+    _serverReceive = (delegate* unmanaged<int, byte, byte*, int, void>)fn;
   }
 
   [UnmanagedCallersOnly]
@@ -92,9 +94,24 @@ public static unsafe class Transport
   // Backends call these from their socket threads to push an inbound (type, payload) up to C++. The C++
   // MessageQueue behind the callback is thread-safe.
 
-  internal static void DeliverServer(byte type, byte[] payload)
+  internal static void DeliverServer(int connId, byte type, byte[] payload)
   {
-    Deliver(_serverReceive, type, payload);
+    var callback = _serverReceive;
+    if (callback == null)
+    {
+      return;
+    }
+
+    if (payload.Length == 0)
+    {
+      callback(connId, type, null, 0);
+      return;
+    }
+
+    fixed (byte* p = payload)
+    {
+      callback(connId, type, p, payload.Length);
+    }
   }
 
   internal static void DeliverClient(byte type, byte[] payload)

--- a/source/libs/net/Transport/WebSocketBackend.cs
+++ b/source/libs/net/Transport/WebSocketBackend.cs
@@ -52,6 +52,10 @@ internal sealed class WebSocketBackend : TransportBackend
   private readonly List<Connection> _connections = new();
   private readonly object _clientsLock = new();
 
+  // A stable, monotonically-increasing id handed to each accepted connection, surfaced to C++ on every
+  // inbound message so the server can keep per-client state (e.g. input). Never reused within a run.
+  private int _nextConnId;
+
   // -- Client --
   private WebSocket? _client;
   private HttpMessageInvoker? _clientInvoker;
@@ -187,6 +191,8 @@ internal sealed class WebSocketBackend : TransportBackend
         return;
       }
 
+      var connId = Interlocked.Increment(ref _nextConnId);
+
       conn = new Connection(ws, cts);
       lock (_clientsLock)
       {
@@ -201,7 +207,7 @@ internal sealed class WebSocketBackend : TransportBackend
           break;
         }
 
-        Transport.DeliverServer(message[0], Payload(message));
+        Transport.DeliverServer(connId, message[0], Payload(message));
       }
     }
     catch

--- a/source/libs/net/Transport/WebSocketBackend.cs
+++ b/source/libs/net/Transport/WebSocketBackend.cs
@@ -165,6 +165,7 @@ internal sealed class WebSocketBackend : TransportBackend
     WebSocket? ws = null;
     CancellationTokenSource? cts = null;
     Connection? conn = null;
+    var connId = 0;
 
     try
     {
@@ -191,7 +192,7 @@ internal sealed class WebSocketBackend : TransportBackend
         return;
       }
 
-      var connId = Interlocked.Increment(ref _nextConnId);
+      connId = Interlocked.Increment(ref _nextConnId);
 
       conn = new Connection(ws, cts);
       lock (_clientsLock)
@@ -222,6 +223,10 @@ internal sealed class WebSocketBackend : TransportBackend
         {
           _connections.Remove(conn);
         }
+
+        // Release any player slot the server bound to this connection (only admitted connections, which
+        // are the ones that got a connId, reach here with conn != null).
+        Transport.DeliverServerDisconnect(connId);
       }
 
       if (ws != null)

--- a/source/libs/protocol/Protocol.h
+++ b/source/libs/protocol/Protocol.h
@@ -22,7 +22,9 @@ enum class MessageType : uint8_t {
   join,         // client -> server: request the initial Snapshot (carries role + auth at handshake)
   snapshot,     // server -> client: full project/scene state (ProjectPacker::pack())
   stateDelta,   // server -> client: per-tick transform stream, packed binary (replication::packStateDelta)
-  inputState,    // client -> server: local input ({ keys, focused }) for the scripts to read
+  inputState,    // client -> server: local input for the scripts to read. Payload: focused (bool),
+                 // key count (size_t) + that many key codes (int), then the mouse block: mouseX, mouseY,
+                 // mouseDeltaX, mouseDeltaY, scrollY (5x float), buttons (uint8 bitmask L/R/M)
   editComponent, // editor -> server -> all: a single component value edit (replication::buildComponentEdit)
   sceneEdit,     // editor -> server: a structural edit (add/remove object/component); server re-snapshots
   sceneControl,  // editor -> server: scene lifecycle (SceneControlOp + optional scene uuid); server re-snapshots

--- a/source/libs/render/InputCapture.cpp
+++ b/source/libs/render/InputCapture.cpp
@@ -30,6 +30,25 @@ InputSnapshot capture(const vke::VulkanEngine& renderer)
   poll(65, 90);    // A-Z
   poll(262, 265);  // right/left/down/up arrows
 
+  // Mouse: absolute cursor position, this frame's movement (current - previous cursor, both cached by
+  // the window each frame), the vertical scroll accumulated this frame, and the button state as a mask.
+  double cursorX = 0.0, cursorY = 0.0;
+  window->getCursorPos(cursorX, cursorY);
+  snapshot.mouseX = static_cast<float>(cursorX);
+  snapshot.mouseY = static_cast<float>(cursorY);
+
+  double prevX = 0.0, prevY = 0.0;
+  window->getPreviousCursorPos(prevX, prevY);
+  snapshot.mouseDeltaX = static_cast<float>(cursorX - prevX);
+  snapshot.mouseDeltaY = static_cast<float>(cursorY - prevY);
+
+  snapshot.scrollY = static_cast<float>(window->getScroll());
+
+  // GLFW_MOUSE_BUTTON_{LEFT,RIGHT,MIDDLE} are 0/1/2; pack them into the MouseButtonBit mask.
+  if (window->buttonIsPressed(0)) { snapshot.buttons |= mouseButtonLeft; }
+  if (window->buttonIsPressed(1)) { snapshot.buttons |= mouseButtonRight; }
+  if (window->buttonIsPressed(2)) { snapshot.buttons |= mouseButtonMiddle; }
+
   return snapshot;
 }
 

--- a/source/libs/render/InputCapture.h
+++ b/source/libs/render/InputCapture.h
@@ -1,20 +1,37 @@
 #ifndef INPUTCAPTURE_H
 #define INPUTCAPTURE_H
 
+#include <cstdint>
 #include <vector>
 
 namespace vke {
   class VulkanEngine;
 }
 
-// Captures the local keyboard so a client/editor can ship it to the authoritative server as an
+// Captures the local keyboard + mouse so a client/editor can ship it to the authoritative server as an
 // inputState message (the server is headless and has no window of its own). Lives in ECS3DRender
 // because it reads the renderer's GLFW window.
 namespace input {
 
+// Mouse button bits, matching GLFW_MOUSE_BUTTON_{LEFT,RIGHT,MIDDLE} (0/1/2) via (1 << button).
+enum MouseButtonBit : uint8_t {
+  mouseButtonLeft   = 1u << 0,
+  mouseButtonRight  = 1u << 1,
+  mouseButtonMiddle = 1u << 2
+};
+
 struct InputSnapshot {
   std::vector<int> keys;   // currently-pressed key codes (GLFW), as the scripts' Key enum expects
   bool focused = true;     // the window only reports keys while it has focus, so this is informational
+
+  // Mouse. Position is absolute (window pixels); delta is this frame's movement (cursor - previous
+  // cursor); scroll is this frame's vertical wheel offset. buttons is a MouseButtonBit mask.
+  float mouseX = 0.0f;
+  float mouseY = 0.0f;
+  float mouseDeltaX = 0.0f;
+  float mouseDeltaY = 0.0f;
+  float scrollY = 0.0f;
+  uint8_t buttons = 0;
 };
 
 [[nodiscard]] InputSnapshot capture(const vke::VulkanEngine& renderer);

--- a/source/libs/scripting/ScriptBridge/ScriptBase.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBase.cs
@@ -11,10 +11,16 @@ public abstract class ScriptBase
 
     protected Transform transform { get; private set; } = null!;
 
+    // This script's own player's input, resolved through its object's PlayerController. Reads as "nothing
+    // pressed" if the object has no PlayerController. Prefer this over the global InputUtils, which reads
+    // every player's input aggregated together.
+    protected PlayerInput input { get; private set; } = null!;
+
     internal void initComponents()
     {
         rigidBody = new RigidBody(EntityId);
         transform = new Transform(EntityId);
+        input = new PlayerInput(EntityId);
     }
 
     // Reach another script by type. Returns null if the object has no script of type T (or no such

--- a/source/libs/scripting/ScriptBridge/components/InputUtils.cs
+++ b/source/libs/scripting/ScriptBridge/components/InputUtils.cs
@@ -22,8 +22,14 @@ public unsafe struct InputUtilsBindings
 {
     public delegate* unmanaged<int, bool> keyIsPressed;
     public delegate* unmanaged<bool> windowIsFocused;
+    // Per-player: resolve the object's PlayerController.playerSlot and read that player's input. New
+    // fields go at the END to keep the layout matched with the native InputUtilsBindings struct.
+    public delegate* unmanaged<IntPtr, int, bool> keyIsPressedForObject;
+    public delegate* unmanaged<IntPtr, bool> windowIsFocusedForObject;
 }
 
+// Player-agnostic input: reads the aggregate across all players (a key is pressed if any player presses
+// it). For a specific player's input, use ScriptBase.input (backed by PlayerInput) instead.
 public static unsafe class InputUtils
 {
     private static bool keyIsPressed(int key) => NativeBindings.InputUtils.keyIsPressed(key);
@@ -31,4 +37,27 @@ public static unsafe class InputUtils
     public static bool keyIsPressed(Key key) => keyIsPressed((int)key);
 
     public static bool windowIsFocused() => NativeBindings.InputUtils.windowIsFocused();
+}
+
+// A single player's input, scoped to the object it was constructed from: it reads only that object's
+// player slot (via its PlayerController). ScriptBase exposes one as `input`, bound to the script's own
+// object, so `input.keyIsPressed(Key.W)` reads this player and no other. Reads as "nothing pressed" when
+// the object has no PlayerController.
+public sealed unsafe class PlayerInput
+{
+    private readonly IntPtr _uuid;
+
+    internal PlayerInput(string uuid)
+    {
+        _uuid = Marshal.StringToCoTaskMemUTF8(uuid);
+    }
+
+    ~PlayerInput()
+    {
+        Marshal.FreeCoTaskMem(_uuid);
+    }
+
+    public bool keyIsPressed(Key key) => NativeBindings.InputUtils.keyIsPressedForObject(_uuid, (int)key);
+
+    public bool windowIsFocused() => NativeBindings.InputUtils.windowIsFocusedForObject(_uuid);
 }

--- a/source/libs/scripting/ScriptBridge/components/InputUtils.cs
+++ b/source/libs/scripting/ScriptBridge/components/InputUtils.cs
@@ -1,7 +1,16 @@
 using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace ScriptBridge;
+
+// GLFW mouse-button indices (0/1/2), used with PlayerInput.mouseButton.
+public enum MouseButton
+{
+    Left   = 0,
+    Right  = 1,
+    Middle = 2,
+}
 
 public enum Key
 {
@@ -26,6 +35,10 @@ public unsafe struct InputUtilsBindings
     // fields go at the END to keep the layout matched with the native InputUtilsBindings struct.
     public delegate* unmanaged<IntPtr, int, bool> keyIsPressedForObject;
     public delegate* unmanaged<IntPtr, bool> windowIsFocusedForObject;
+    public delegate* unmanaged<IntPtr, float*, float*, void> mousePositionForObject;
+    public delegate* unmanaged<IntPtr, float*, float*, void> mouseDeltaForObject;
+    public delegate* unmanaged<IntPtr, float> scrollForObject;
+    public delegate* unmanaged<IntPtr, int, bool> mouseButtonForObject;
 }
 
 // Player-agnostic input: reads the aggregate across all players (a key is pressed if any player presses
@@ -60,4 +73,25 @@ public sealed unsafe class PlayerInput
     public bool keyIsPressed(Key key) => NativeBindings.InputUtils.keyIsPressedForObject(_uuid, (int)key);
 
     public bool windowIsFocused() => NativeBindings.InputUtils.windowIsFocusedForObject(_uuid);
+
+    // Absolute cursor position in window pixels.
+    public Vector2 mousePosition()
+    {
+        float x = 0, y = 0;
+        NativeBindings.InputUtils.mousePositionForObject(_uuid, &x, &y);
+        return new Vector2(x, y);
+    }
+
+    // Cursor movement over this tick (sums every frame the client sent since the last tick).
+    public Vector2 mouseDelta()
+    {
+        float x = 0, y = 0;
+        NativeBindings.InputUtils.mouseDeltaForObject(_uuid, &x, &y);
+        return new Vector2(x, y);
+    }
+
+    // Vertical scroll-wheel movement over this tick.
+    public float scroll() => NativeBindings.InputUtils.scrollForObject(_uuid);
+
+    public bool mouseButton(MouseButton button) => NativeBindings.InputUtils.mouseButtonForObject(_uuid, (int)button);
 }

--- a/source/libs/scripting/ScriptBridge/components/InputUtils.cs
+++ b/source/libs/scripting/ScriptBridge/components/InputUtils.cs
@@ -39,6 +39,8 @@ public unsafe struct InputUtilsBindings
     public delegate* unmanaged<IntPtr, float*, float*, void> mouseDeltaForObject;
     public delegate* unmanaged<IntPtr, float> scrollForObject;
     public delegate* unmanaged<IntPtr, int, bool> mouseButtonForObject;
+    public delegate* unmanaged<IntPtr, int, bool> wasKeyPressedThisTickForObject;
+    public delegate* unmanaged<IntPtr, int, bool> wasKeyReleasedThisTickForObject;
 }
 
 // Player-agnostic input: reads the aggregate across all players (a key is pressed if any player presses
@@ -71,6 +73,11 @@ public sealed unsafe class PlayerInput
     }
 
     public bool keyIsPressed(Key key) => NativeBindings.InputUtils.keyIsPressedForObject(_uuid, (int)key);
+
+    // True only on the tick the key transitions down / up (edge), vs. keyIsPressed which is level.
+    public bool wasPressedThisTick(Key key) => NativeBindings.InputUtils.wasKeyPressedThisTickForObject(_uuid, (int)key);
+
+    public bool wasReleasedThisTick(Key key) => NativeBindings.InputUtils.wasKeyReleasedThisTickForObject(_uuid, (int)key);
 
     public bool windowIsFocused() => NativeBindings.InputUtils.windowIsFocusedForObject(_uuid);
 

--- a/source/libs/scripting/UserScripts/PlayerScript.cs
+++ b/source/libs/scripting/UserScripts/PlayerScript.cs
@@ -60,18 +60,18 @@ public class PlayerScript : ScriptBase
 
     private void handleInput()
     {
-        if (!InputUtils.windowIsFocused())
+        if (!input.windowIsFocused())
         {
             return;
         }
 
         float xForce = 0;
-        if (InputUtils.keyIsPressed(Key.LEFT))
+        if (input.keyIsPressed(Key.LEFT))
         {
             xForce += m_speed;
         }
 
-        if (InputUtils.keyIsPressed(Key.RIGHT))
+        if (input.keyIsPressed(Key.RIGHT))
         {
             xForce -= m_speed;
         }
@@ -82,12 +82,12 @@ public class PlayerScript : ScriptBase
         }
 
         float zForce = 0;
-        if (InputUtils.keyIsPressed(Key.UP))
+        if (input.keyIsPressed(Key.UP))
         {
             zForce += m_speed;
         }
 
-        if (InputUtils.keyIsPressed(Key.DOWN))
+        if (input.keyIsPressed(Key.DOWN))
         {
             zForce -= m_speed;
         }
@@ -97,7 +97,7 @@ public class PlayerScript : ScriptBase
             m_appliedForce.Z = zForce;
         }
 
-        if (!m_wasJumping && !rigidBody.isFalling() && InputUtils.keyIsPressed(Key.X))
+        if (!m_wasJumping && !rigidBody.isFalling() && input.keyIsPressed(Key.X))
         {
             m_appliedForce.Y = m_jumpForce;
             m_wasJumping = true;

--- a/source/libs/scripting/bindings/InputState.cpp
+++ b/source/libs/scripting/bindings/InputState.cpp
@@ -1,34 +1,39 @@
 #include "InputState.h"
 
-std::unordered_map<int32_t, InputState::ConnectionInput> InputState::s_connections;
+std::unordered_map<int32_t, InputState::SlotInput> InputState::s_slots;
 
-void InputState::setKeysPressed(const int32_t connectionId, const std::vector<int>& keys)
+void InputState::setKeysPressed(const int32_t playerSlot, const std::vector<int>& keys)
 {
-  auto& slot = s_connections[connectionId];
+  auto& slot = s_slots[playerSlot];
   slot.pressedKeys.clear();
   slot.pressedKeys.insert(keys.begin(), keys.end());
 }
 
-void InputState::setFocused(const int32_t connectionId, const bool focused)
+void InputState::setFocused(const int32_t playerSlot, const bool focused)
 {
-  s_connections[connectionId].focused = focused;
+  s_slots[playerSlot].focused = focused;
 }
 
-bool InputState::isKeyPressed(const int32_t connectionId, const int key)
+void InputState::removeSlot(const int32_t playerSlot)
 {
-  const auto it = s_connections.find(connectionId);
-  return it != s_connections.end() && it->second.pressedKeys.contains(key);
+  s_slots.erase(playerSlot);
 }
 
-bool InputState::isFocused(const int32_t connectionId)
+bool InputState::isKeyPressed(const int32_t playerSlot, const int key)
 {
-  const auto it = s_connections.find(connectionId);
-  return it != s_connections.end() && it->second.focused;
+  const auto it = s_slots.find(playerSlot);
+  return it != s_slots.end() && it->second.pressedKeys.contains(key);
+}
+
+bool InputState::isFocused(const int32_t playerSlot)
+{
+  const auto it = s_slots.find(playerSlot);
+  return it != s_slots.end() && it->second.focused;
 }
 
 bool InputState::isAnyKeyPressed(const int key)
 {
-  for (const auto& [id, input] : s_connections)
+  for (const auto& [slot, input] : s_slots)
   {
     if (input.pressedKeys.contains(key))
     {
@@ -41,7 +46,7 @@ bool InputState::isAnyKeyPressed(const int key)
 
 bool InputState::isAnyFocused()
 {
-  for (const auto& [id, input] : s_connections)
+  for (const auto& [slot, input] : s_slots)
   {
     if (input.focused)
     {

--- a/source/libs/scripting/bindings/InputState.cpp
+++ b/source/libs/scripting/bindings/InputState.cpp
@@ -38,6 +38,14 @@ void InputState::clearMouseDeltas()
   }
 }
 
+void InputState::commitInputEdges()
+{
+  for (auto& [slot, input] : s_slots)
+  {
+    input.previousKeys = input.pressedKeys;
+  }
+}
+
 void InputState::removeSlot(const int32_t playerSlot)
 {
   s_slots.erase(playerSlot);
@@ -47,6 +55,22 @@ bool InputState::isKeyPressed(const int32_t playerSlot, const int key)
 {
   const auto it = s_slots.find(playerSlot);
   return it != s_slots.end() && it->second.pressedKeys.contains(key);
+}
+
+bool InputState::wasKeyPressedThisTick(const int32_t playerSlot, const int key)
+{
+  const auto it = s_slots.find(playerSlot);
+  return it != s_slots.end()
+    && it->second.pressedKeys.contains(key)
+    && !it->second.previousKeys.contains(key);
+}
+
+bool InputState::wasKeyReleasedThisTick(const int32_t playerSlot, const int key)
+{
+  const auto it = s_slots.find(playerSlot);
+  return it != s_slots.end()
+    && !it->second.pressedKeys.contains(key)
+    && it->second.previousKeys.contains(key);
 }
 
 bool InputState::isFocused(const int32_t playerSlot)

--- a/source/libs/scripting/bindings/InputState.cpp
+++ b/source/libs/scripting/bindings/InputState.cpp
@@ -1,25 +1,53 @@
 #include "InputState.h"
 
-std::unordered_set<int> InputState::s_pressedKeys;
-bool InputState::s_focused = false;
+std::unordered_map<int32_t, InputState::ConnectionInput> InputState::s_connections;
 
-void InputState::setKeysPressed(const std::vector<int>& keys)
+void InputState::setKeysPressed(const int32_t connectionId, const std::vector<int>& keys)
 {
-  s_pressedKeys.clear();
-  s_pressedKeys.insert(keys.begin(), keys.end());
+  auto& slot = s_connections[connectionId];
+  slot.pressedKeys.clear();
+  slot.pressedKeys.insert(keys.begin(), keys.end());
 }
 
-void InputState::setFocused(const bool focused)
+void InputState::setFocused(const int32_t connectionId, const bool focused)
 {
-  s_focused = focused;
+  s_connections[connectionId].focused = focused;
 }
 
-bool InputState::isKeyPressed(const int key)
+bool InputState::isKeyPressed(const int32_t connectionId, const int key)
 {
-  return s_pressedKeys.contains(key);
+  const auto it = s_connections.find(connectionId);
+  return it != s_connections.end() && it->second.pressedKeys.contains(key);
 }
 
-bool InputState::isFocused()
+bool InputState::isFocused(const int32_t connectionId)
 {
-  return s_focused;
+  const auto it = s_connections.find(connectionId);
+  return it != s_connections.end() && it->second.focused;
+}
+
+bool InputState::isAnyKeyPressed(const int key)
+{
+  for (const auto& [id, input] : s_connections)
+  {
+    if (input.pressedKeys.contains(key))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool InputState::isAnyFocused()
+{
+  for (const auto& [id, input] : s_connections)
+  {
+    if (input.focused)
+    {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/source/libs/scripting/bindings/InputState.cpp
+++ b/source/libs/scripting/bindings/InputState.cpp
@@ -14,6 +14,30 @@ void InputState::setFocused(const int32_t playerSlot, const bool focused)
   s_slots[playerSlot].focused = focused;
 }
 
+void InputState::setMouse(const int32_t playerSlot, const float x, const float y, const float deltaX,
+                          const float deltaY, const float scrollY, const uint8_t buttons)
+{
+  auto& slot = s_slots[playerSlot];
+  slot.mouseX = x;
+  slot.mouseY = y;
+  slot.buttons = buttons;
+
+  // Accumulate motion between ticks so several sub-frame moves add up instead of overwriting each other.
+  slot.mouseDeltaX += deltaX;
+  slot.mouseDeltaY += deltaY;
+  slot.scrollY += scrollY;
+}
+
+void InputState::clearMouseDeltas()
+{
+  for (auto& [slot, input] : s_slots)
+  {
+    input.mouseDeltaX = 0.0f;
+    input.mouseDeltaY = 0.0f;
+    input.scrollY = 0.0f;
+  }
+}
+
 void InputState::removeSlot(const int32_t playerSlot)
 {
   s_slots.erase(playerSlot);
@@ -29,6 +53,37 @@ bool InputState::isFocused(const int32_t playerSlot)
 {
   const auto it = s_slots.find(playerSlot);
   return it != s_slots.end() && it->second.focused;
+}
+
+void InputState::getMousePosition(const int32_t playerSlot, float& x, float& y)
+{
+  const auto it = s_slots.find(playerSlot);
+  x = it != s_slots.end() ? it->second.mouseX : 0.0f;
+  y = it != s_slots.end() ? it->second.mouseY : 0.0f;
+}
+
+void InputState::getMouseDelta(const int32_t playerSlot, float& deltaX, float& deltaY)
+{
+  const auto it = s_slots.find(playerSlot);
+  deltaX = it != s_slots.end() ? it->second.mouseDeltaX : 0.0f;
+  deltaY = it != s_slots.end() ? it->second.mouseDeltaY : 0.0f;
+}
+
+float InputState::getScroll(const int32_t playerSlot)
+{
+  const auto it = s_slots.find(playerSlot);
+  return it != s_slots.end() ? it->second.scrollY : 0.0f;
+}
+
+bool InputState::isMouseButtonPressed(const int32_t playerSlot, const int button)
+{
+  if (button < 0 || button > 7)
+  {
+    return false;
+  }
+
+  const auto it = s_slots.find(playerSlot);
+  return it != s_slots.end() && (it->second.buttons & (1u << button)) != 0u;
 }
 
 bool InputState::isAnyKeyPressed(const int key)

--- a/source/libs/scripting/bindings/InputState.h
+++ b/source/libs/scripting/bindings/InputState.h
@@ -1,27 +1,49 @@
 #ifndef INPUTSTATE_H
 #define INPUTSTATE_H
 
+#include <cstdint>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 // The networked input the headless server feeds to the scripts. A client/editor (which owns the GLFW
 // window) captures the pressed keys each frame and sends them as an inputState message; ServerApp
-// writes them here, and the InputUtils bindings read them. Set + read happen on the server's main
-// loop thread (the inputState message is drained and the scripts run on the same thread), so no
-// locking is needed.
+// writes them here, and the InputUtils bindings read them.
+//
+// State is kept per connection (Phase 3.1): each connected client gets its own slot keyed by the stable
+// connection id NetServer surfaces alongside inbound messages, so two players no longer clobber one
+// shared key set. The (player-agnostic) script bindings still read the aggregate across all connections
+// until Phase 3.2 gives a script its own player identity — a key reads as pressed if any connection is
+// pressing it.
+//
+// Set + read happen on the server's main loop thread (the inputState message is drained and the scripts
+// run on the same thread), so no locking is needed.
 class InputState {
 public:
-  static void setKeysPressed(const std::vector<int>& keys);
+  // Per-connection writes: the server drops each client's inputState into its own slot.
+  static void setKeysPressed(int32_t connectionId, const std::vector<int>& keys);
 
-  static void setFocused(bool focused);
+  static void setFocused(int32_t connectionId, bool focused);
 
-  [[nodiscard]] static bool isKeyPressed(int key);
+  // Per-connection queries (used once a script knows which player it belongs to — Phase 3.2).
+  [[nodiscard]] static bool isKeyPressed(int32_t connectionId, int key);
 
-  [[nodiscard]] static bool isFocused();
+  [[nodiscard]] static bool isFocused(int32_t connectionId);
+
+  // Aggregate across every connection — the bridge the player-agnostic script bindings read until 3.2.
+  // A key is "pressed" if any connection presses it; "focused" if any connection is focused. In the
+  // singleplayer case (one connection) this is identical to the old single-slot behavior.
+  [[nodiscard]] static bool isAnyKeyPressed(int key);
+
+  [[nodiscard]] static bool isAnyFocused();
 
 private:
-  static std::unordered_set<int> s_pressedKeys;
-  static bool s_focused;
+  struct ConnectionInput {
+    std::unordered_set<int> pressedKeys;
+    bool focused = false;
+  };
+
+  static std::unordered_map<int32_t, ConnectionInput> s_connections;
 };
 
 

--- a/source/libs/scripting/bindings/InputState.h
+++ b/source/libs/scripting/bindings/InputState.h
@@ -10,40 +10,42 @@
 // window) captures the pressed keys each frame and sends them as an inputState message; ServerApp
 // writes them here, and the InputUtils bindings read them.
 //
-// State is kept per connection (Phase 3.1): each connected client gets its own slot keyed by the stable
-// connection id NetServer surfaces alongside inbound messages, so two players no longer clobber one
-// shared key set. The (player-agnostic) script bindings still read the aggregate across all connections
-// until Phase 3.2 gives a script its own player identity — a key reads as pressed if any connection is
-// pressing it.
+// State is kept per player slot (Phase 3.2): the server binds each connection to a player slot and drops
+// that connection's input into its slot, so two players no longer clobber one shared key set. A script
+// reads its own player's input by resolving its object's PlayerController.playerSlot to a slot here
+// (ScriptBase.input); the player-agnostic global InputUtils reads the aggregate across all slots.
 //
 // Set + read happen on the server's main loop thread (the inputState message is drained and the scripts
 // run on the same thread), so no locking is needed.
 class InputState {
 public:
-  // Per-connection writes: the server drops each client's inputState into its own slot.
-  static void setKeysPressed(int32_t connectionId, const std::vector<int>& keys);
+  // Per-slot writes: the server drops each player's inputState into its own slot.
+  static void setKeysPressed(int32_t playerSlot, const std::vector<int>& keys);
 
-  static void setFocused(int32_t connectionId, bool focused);
+  static void setFocused(int32_t playerSlot, bool focused);
 
-  // Per-connection queries (used once a script knows which player it belongs to — Phase 3.2).
-  [[nodiscard]] static bool isKeyPressed(int32_t connectionId, int key);
+  // Drop a slot's state when its player disconnects, so a departed player's last keys don't linger.
+  static void removeSlot(int32_t playerSlot);
 
-  [[nodiscard]] static bool isFocused(int32_t connectionId);
+  // Per-slot queries (used once a script knows which player it belongs to, via PlayerController).
+  [[nodiscard]] static bool isKeyPressed(int32_t playerSlot, int key);
 
-  // Aggregate across every connection — the bridge the player-agnostic script bindings read until 3.2.
-  // A key is "pressed" if any connection presses it; "focused" if any connection is focused. In the
-  // singleplayer case (one connection) this is identical to the old single-slot behavior.
+  [[nodiscard]] static bool isFocused(int32_t playerSlot);
+
+  // Aggregate across every slot — what the player-agnostic global InputUtils reads. A key is "pressed"
+  // if any player presses it; "focused" if any player is focused. In the singleplayer case (one slot)
+  // this is identical to the old single-slot behavior.
   [[nodiscard]] static bool isAnyKeyPressed(int key);
 
   [[nodiscard]] static bool isAnyFocused();
 
 private:
-  struct ConnectionInput {
+  struct SlotInput {
     std::unordered_set<int> pressedKeys;
     bool focused = false;
   };
 
-  static std::unordered_map<int32_t, ConnectionInput> s_connections;
+  static std::unordered_map<int32_t, SlotInput> s_slots;
 };
 
 

--- a/source/libs/scripting/bindings/InputState.h
+++ b/source/libs/scripting/bindings/InputState.h
@@ -34,11 +34,21 @@ public:
   // scripts consume them, so a still mouse reads zero delta rather than a stale value.
   static void clearMouseDeltas();
 
+  // Snapshot every slot's current keys as "last tick's" keys. Called once per fixed tick after the
+  // scripts consume the edges, so wasPressed/ReleasedThisTick diff this tick's keys against last tick's.
+  static void commitInputEdges();
+
   // Drop a slot's state when its player disconnects, so a departed player's last keys don't linger.
   static void removeSlot(int32_t playerSlot);
 
   // Per-slot queries (used once a script knows which player it belongs to, via PlayerController).
   [[nodiscard]] static bool isKeyPressed(int32_t playerSlot, int key);
+
+  // Edge queries against last tick's key set (see commitInputEdges): pressed = down now but not last
+  // tick; released = down last tick but not now.
+  [[nodiscard]] static bool wasKeyPressedThisTick(int32_t playerSlot, int key);
+
+  [[nodiscard]] static bool wasKeyReleasedThisTick(int32_t playerSlot, int key);
 
   [[nodiscard]] static bool isFocused(int32_t playerSlot);
 
@@ -61,6 +71,7 @@ public:
 private:
   struct SlotInput {
     std::unordered_set<int> pressedKeys;
+    std::unordered_set<int> previousKeys;  // last tick's pressedKeys, for edge detection
     bool focused = false;
 
     float mouseX = 0.0f;

--- a/source/libs/scripting/bindings/InputState.h
+++ b/source/libs/scripting/bindings/InputState.h
@@ -24,6 +24,16 @@ public:
 
   static void setFocused(int32_t playerSlot, bool focused);
 
+  // Per-slot mouse write for one inputState message. Position and buttons are the latest values; delta
+  // and scroll are per-frame amounts that ACCUMULATE across the messages received between ticks (so no
+  // movement is lost when the client sends faster than the tick rate) and are zeroed by clearMouseDeltas.
+  static void setMouse(int32_t playerSlot, float x, float y, float deltaX, float deltaY,
+                       float scrollY, uint8_t buttons);
+
+  // Reset every slot's accumulated mouse delta + scroll to zero. Called once per fixed tick after the
+  // scripts consume them, so a still mouse reads zero delta rather than a stale value.
+  static void clearMouseDeltas();
+
   // Drop a slot's state when its player disconnects, so a departed player's last keys don't linger.
   static void removeSlot(int32_t playerSlot);
 
@@ -31,6 +41,15 @@ public:
   [[nodiscard]] static bool isKeyPressed(int32_t playerSlot, int key);
 
   [[nodiscard]] static bool isFocused(int32_t playerSlot);
+
+  static void getMousePosition(int32_t playerSlot, float& x, float& y);
+
+  static void getMouseDelta(int32_t playerSlot, float& deltaX, float& deltaY);
+
+  [[nodiscard]] static float getScroll(int32_t playerSlot);
+
+  // button is the GLFW mouse-button index (0 = left, 1 = right, 2 = middle).
+  [[nodiscard]] static bool isMouseButtonPressed(int32_t playerSlot, int button);
 
   // Aggregate across every slot — what the player-agnostic global InputUtils reads. A key is "pressed"
   // if any player presses it; "focused" if any player is focused. In the singleplayer case (one slot)
@@ -43,6 +62,13 @@ private:
   struct SlotInput {
     std::unordered_set<int> pressedKeys;
     bool focused = false;
+
+    float mouseX = 0.0f;
+    float mouseY = 0.0f;
+    float mouseDeltaX = 0.0f;  // accumulated since the last clearMouseDeltas
+    float mouseDeltaY = 0.0f;
+    float scrollY = 0.0f;      // accumulated since the last clearMouseDeltas
+    uint8_t buttons = 0;
   };
 
   static std::unordered_map<int32_t, SlotInput> s_slots;

--- a/source/libs/scripting/bindings/InputUtilsBindings.cpp
+++ b/source/libs/scripting/bindings/InputUtilsBindings.cpp
@@ -51,7 +51,9 @@ InputUtilsBindings InputUtilsBindingsProvider::getBindings()
     .mousePositionForObject = &bindMousePositionForObject,
     .mouseDeltaForObject = &bindMouseDeltaForObject,
     .scrollForObject = &bindScrollForObject,
-    .mouseButtonForObject = &bindMouseButtonForObject
+    .mouseButtonForObject = &bindMouseButtonForObject,
+    .wasKeyPressedThisTickForObject = &bindWasKeyPressedThisTickForObject,
+    .wasKeyReleasedThisTickForObject = &bindWasKeyReleasedThisTickForObject
   };
 }
 
@@ -111,4 +113,16 @@ bool InputUtilsBindingsProvider::bindMouseButtonForObject(const char* uuid, cons
 {
   const auto slot = playerSlotOf(uuid);
   return slot.has_value() && InputState::isMouseButtonPressed(slot.value(), button);
+}
+
+bool InputUtilsBindingsProvider::bindWasKeyPressedThisTickForObject(const char* uuid, const int key)
+{
+  const auto slot = playerSlotOf(uuid);
+  return slot.has_value() && InputState::wasKeyPressedThisTick(slot.value(), key);
+}
+
+bool InputUtilsBindingsProvider::bindWasKeyReleasedThisTickForObject(const char* uuid, const int key)
+{
+  const auto slot = playerSlotOf(uuid);
+  return slot.has_value() && InputState::wasKeyReleasedThisTick(slot.value(), key);
 }

--- a/source/libs/scripting/bindings/InputUtilsBindings.cpp
+++ b/source/libs/scripting/bindings/InputUtilsBindings.cpp
@@ -1,22 +1,76 @@
 #include "InputUtilsBindings.h"
 #include "InputState.h"
+#include "BindingContext.h"
+#include <objects/Object.h>
+#include <objects/ObjectManager.h>
+#include <objects/components/Component.h>
+#include <objects/components/PlayerController.h>
+#include <optional>
+#include <string>
+
+namespace {
+  // Resolve an object's player slot from its PlayerController. Returns nullopt when the object doesn't
+  // exist or carries no PlayerController (so per-player input reads as "nothing pressed").
+  std::optional<int32_t> playerSlotOf(const char* uuid)
+  {
+    const auto objectManager = BindingContext::getObjectManager();
+    if (!objectManager)
+    {
+      return std::nullopt;
+    }
+
+    const auto parsed = uuids::uuid::from_string(std::string(uuid));
+    if (!parsed.has_value())
+    {
+      return std::nullopt;
+    }
+
+    const auto object = objectManager->getObjectByUUID(parsed.value());
+    if (!object)
+    {
+      return std::nullopt;
+    }
+
+    const auto playerController = object->getComponent<PlayerController>(ComponentType::playerController);
+    if (!playerController)
+    {
+      return std::nullopt;
+    }
+
+    return playerController->getPlayerSlot();
+  }
+}
 
 InputUtilsBindings InputUtilsBindingsProvider::getBindings()
 {
   return InputUtilsBindings {
     .keyIsPressed = &bindKeyIsPressed,
-    .windowIsFocused = &bindWindowIsFocused
+    .windowIsFocused = &bindWindowIsFocused,
+    .keyIsPressedForObject = &bindKeyIsPressedForObject,
+    .windowIsFocusedForObject = &bindWindowIsFocusedForObject
   };
 }
 
 bool InputUtilsBindingsProvider::bindKeyIsPressed(const int key)
 {
-  // Player-agnostic for now: a key reads as pressed if any connection presses it. Phase 3.2 gives a
-  // script its own player identity and switches this to the per-connection query.
+  // Player-agnostic: a key reads as pressed if any player presses it. Scripts that want a specific
+  // player's input read through ScriptBase.input (the *ForObject path below).
   return InputState::isAnyKeyPressed(key);
 }
 
 bool InputUtilsBindingsProvider::bindWindowIsFocused()
 {
   return InputState::isAnyFocused();
+}
+
+bool InputUtilsBindingsProvider::bindKeyIsPressedForObject(const char* uuid, const int key)
+{
+  const auto slot = playerSlotOf(uuid);
+  return slot.has_value() && InputState::isKeyPressed(slot.value(), key);
+}
+
+bool InputUtilsBindingsProvider::bindWindowIsFocusedForObject(const char* uuid)
+{
+  const auto slot = playerSlotOf(uuid);
+  return slot.has_value() && InputState::isFocused(slot.value());
 }

--- a/source/libs/scripting/bindings/InputUtilsBindings.cpp
+++ b/source/libs/scripting/bindings/InputUtilsBindings.cpp
@@ -47,7 +47,11 @@ InputUtilsBindings InputUtilsBindingsProvider::getBindings()
     .keyIsPressed = &bindKeyIsPressed,
     .windowIsFocused = &bindWindowIsFocused,
     .keyIsPressedForObject = &bindKeyIsPressedForObject,
-    .windowIsFocusedForObject = &bindWindowIsFocusedForObject
+    .windowIsFocusedForObject = &bindWindowIsFocusedForObject,
+    .mousePositionForObject = &bindMousePositionForObject,
+    .mouseDeltaForObject = &bindMouseDeltaForObject,
+    .scrollForObject = &bindScrollForObject,
+    .mouseButtonForObject = &bindMouseButtonForObject
   };
 }
 
@@ -73,4 +77,38 @@ bool InputUtilsBindingsProvider::bindWindowIsFocusedForObject(const char* uuid)
 {
   const auto slot = playerSlotOf(uuid);
   return slot.has_value() && InputState::isFocused(slot.value());
+}
+
+void InputUtilsBindingsProvider::bindMousePositionForObject(const char* uuid, float* x, float* y)
+{
+  *x = 0.0f;
+  *y = 0.0f;
+
+  if (const auto slot = playerSlotOf(uuid))
+  {
+    InputState::getMousePosition(slot.value(), *x, *y);
+  }
+}
+
+void InputUtilsBindingsProvider::bindMouseDeltaForObject(const char* uuid, float* x, float* y)
+{
+  *x = 0.0f;
+  *y = 0.0f;
+
+  if (const auto slot = playerSlotOf(uuid))
+  {
+    InputState::getMouseDelta(slot.value(), *x, *y);
+  }
+}
+
+float InputUtilsBindingsProvider::bindScrollForObject(const char* uuid)
+{
+  const auto slot = playerSlotOf(uuid);
+  return slot.has_value() ? InputState::getScroll(slot.value()) : 0.0f;
+}
+
+bool InputUtilsBindingsProvider::bindMouseButtonForObject(const char* uuid, const int button)
+{
+  const auto slot = playerSlotOf(uuid);
+  return slot.has_value() && InputState::isMouseButtonPressed(slot.value(), button);
 }

--- a/source/libs/scripting/bindings/InputUtilsBindings.cpp
+++ b/source/libs/scripting/bindings/InputUtilsBindings.cpp
@@ -11,10 +11,12 @@ InputUtilsBindings InputUtilsBindingsProvider::getBindings()
 
 bool InputUtilsBindingsProvider::bindKeyIsPressed(const int key)
 {
-  return InputState::isKeyPressed(key);
+  // Player-agnostic for now: a key reads as pressed if any connection presses it. Phase 3.2 gives a
+  // script its own player identity and switches this to the per-connection query.
+  return InputState::isAnyKeyPressed(key);
 }
 
 bool InputUtilsBindingsProvider::bindWindowIsFocused()
 {
-  return InputState::isFocused();
+  return InputState::isAnyFocused();
 }

--- a/source/libs/scripting/bindings/InputUtilsBindings.h
+++ b/source/libs/scripting/bindings/InputUtilsBindings.h
@@ -2,12 +2,19 @@
 #define INPUTUTILSBINDINGS_H
 
 // Mirrors the C# InputUtilsBindings struct layout (ScriptBridge/components/InputUtils.cs). The managed
-// InputUtils calls these function pointers; they now read the networked InputState instead of a local
-// GLFW window, since the server is headless.
+// InputUtils calls these function pointers; they read the networked InputState instead of a local GLFW
+// window, since the server is headless.
+//
+// keyIsPressed/windowIsFocused are the player-agnostic aggregate (any player). The *ForObject variants
+// are per-player: given an object uuid they resolve its PlayerController.playerSlot and read that
+// player's slot, so a script reads only its own player's input (ScriptBase.input). New fields go at the
+// END to keep the layout matched with the C# mirror.
 struct InputUtilsBindings
 {
   bool(*keyIsPressed)(int key);
   bool(*windowIsFocused)();
+  bool(*keyIsPressedForObject)(const char* uuid, int key);
+  bool(*windowIsFocusedForObject)(const char* uuid);
 };
 
 class InputUtilsBindingsProvider {
@@ -18,6 +25,10 @@ private:
   static bool bindKeyIsPressed(int key);
 
   static bool bindWindowIsFocused();
+
+  static bool bindKeyIsPressedForObject(const char* uuid, int key);
+
+  static bool bindWindowIsFocusedForObject(const char* uuid);
 };
 
 

--- a/source/libs/scripting/bindings/InputUtilsBindings.h
+++ b/source/libs/scripting/bindings/InputUtilsBindings.h
@@ -21,6 +21,9 @@ struct InputUtilsBindings
   void(*mouseDeltaForObject)(const char* uuid, float* x, float* y);
   float(*scrollForObject)(const char* uuid);
   bool(*mouseButtonForObject)(const char* uuid, int button);
+  // Per-player key edges against last tick (see InputState::commitInputEdges).
+  bool(*wasKeyPressedThisTickForObject)(const char* uuid, int key);
+  bool(*wasKeyReleasedThisTickForObject)(const char* uuid, int key);
 };
 
 class InputUtilsBindingsProvider {
@@ -43,6 +46,10 @@ private:
   static float bindScrollForObject(const char* uuid);
 
   static bool bindMouseButtonForObject(const char* uuid, int button);
+
+  static bool bindWasKeyPressedThisTickForObject(const char* uuid, int key);
+
+  static bool bindWasKeyReleasedThisTickForObject(const char* uuid, int key);
 };
 
 

--- a/source/libs/scripting/bindings/InputUtilsBindings.h
+++ b/source/libs/scripting/bindings/InputUtilsBindings.h
@@ -15,6 +15,12 @@ struct InputUtilsBindings
   bool(*windowIsFocused)();
   bool(*keyIsPressedForObject)(const char* uuid, int key);
   bool(*windowIsFocusedForObject)(const char* uuid);
+  // Per-player mouse (resolved via PlayerController.playerSlot). Position is absolute; delta/scroll are
+  // this tick's accumulated motion; button is the GLFW index (0/1/2).
+  void(*mousePositionForObject)(const char* uuid, float* x, float* y);
+  void(*mouseDeltaForObject)(const char* uuid, float* x, float* y);
+  float(*scrollForObject)(const char* uuid);
+  bool(*mouseButtonForObject)(const char* uuid, int button);
 };
 
 class InputUtilsBindingsProvider {
@@ -29,6 +35,14 @@ private:
   static bool bindKeyIsPressedForObject(const char* uuid, int key);
 
   static bool bindWindowIsFocusedForObject(const char* uuid);
+
+  static void bindMousePositionForObject(const char* uuid, float* x, float* y);
+
+  static void bindMouseDeltaForObject(const char* uuid, float* x, float* y);
+
+  static float bindScrollForObject(const char* uuid);
+
+  static bool bindMouseButtonForObject(const char* uuid, int button);
 };
 
 


### PR DESCRIPTION
This pull request implements per-player input routing and adds a new `PlayerController` component, enabling each client connection to control its own player object without interference. The changes span the client, editor, and server codebases, updating the input protocol, connection management, and default project setup. The most important changes are grouped below:

**Input Protocol and Client/Editor Handling:**

* Expanded the input protocol to include mouse state (position, delta, scroll, buttons) in addition to keyboard state, and updated both `ClientApp` and `EditorApp` to send this data efficiently only when changed or necessary. (`ClientApp.cpp`, `EditorApp.cpp`, `ClientApp.h`, `EditorApp.h`) [[1]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaL87-R109) [[2]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaR120-R126) [[3]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aR5) [[4]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aR66-R68) [[5]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L252-R291) [[6]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R302-R308) [[7]](diffhunk://#diff-9a5c9efc47e4a10dd5c55d5b1972613c1f81ca79c013e4d58c6cad5065890034R7) [[8]](diffhunk://#diff-9a5c9efc47e4a10dd5c55d5b1972613c1f81ca79c013e4d58c6cad5065890034R101-R103)
* Improved editor input handling to prevent game input when the UI is focused, and ensured input is only sent to the server when relevant changes occur. (`EditorApp.cpp`)

**Server-Side Player Slot Assignment and Input Routing:**

* Introduced per-connection player slot assignment: each client is bound to a unique player slot on join, and their input is routed to that slot. Slots are released and cleared when connections drop. (`ServerApp.cpp`, `ServerApp.h`) [[1]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL120-R141) [[2]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL238-R252) [[3]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL250-R264) [[4]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL270-R284) [[5]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL281-R350) [[6]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL413-R483) [[7]](diffhunk://#diff-59a6facf8f8f4ca802ec9e46466dd86b4d1fc813aeaea6dfbce95fae1f4f9292R74-R96) [[8]](diffhunk://#diff-59a6facf8f8f4ca802ec9e46466dd86b4d1fc813aeaea6dfbce95fae1f4f9292L90-R106)
* Updated input handling to use the player slot for all input state, including new mouse data, and made the protocol backward compatible with older clients. (`ServerApp.cpp`) [[1]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL413-R483) [[2]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dL427-R506)

**PlayerController Component and Registration:**

* Added a new `PlayerController` component to associate objects with player slots, registered it in the component system, and included it in the default player object setup. (`PlayerController.cpp/h`, `ComponentRegistration.cpp`, `DefaultProject.cpp`, `CMakeLists.txt`) [[1]](diffhunk://#diff-98d5735e50129b967815a2bc532591e085242e97d75f20019ab851447f592fa9R32-R33) [[2]](diffhunk://#diff-93c701fbab361fd269410ee22c4fdd1f4aab55ded9095650b735688babdf2065R10) [[3]](diffhunk://#diff-93c701fbab361fd269410ee22c4fdd1f4aab55ded9095650b735688babdf2065R31-R33) [[4]](diffhunk://#diff-4a268f41fcddcf2f0fd3076d4eb7c4a6008bb0e22da9c12b28a6c451c8bec440R94-R101) [[5]](diffhunk://#diff-4a268f41fcddcf2f0fd3076d4eb7c4a6008bb0e22da9c12b28a6c451c8bec440L140-R155)
* Registered the `PlayerControllerEditor` in the editor for editing this component. (`EditorApp.cpp`) [[1]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R27) [[2]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R350)

**Project and Protocol Maintenance:**

* Updated CMake and include directives to support the new component and protocol changes. [[1]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aR5) [[2]](diffhunk://#diff-9a5c9efc47e4a10dd5c55d5b1972613c1f81ca79c013e4d58c6cad5065890034R7) [[3]](diffhunk://#diff-98d5735e50129b967815a2bc532591e085242e97d75f20019ab851447f592fa9R32-R33) [[4]](diffhunk://#diff-59a6facf8f8f4ca802ec9e46466dd86b4d1fc813aeaea6dfbce95fae1f4f9292R7-R10)

These changes collectively enable robust, per-player input handling and pave the way for multiplayer features.