### PR TITLE
Add Camera component and integrate with rendering and editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,12 @@
 | `CMakeLists.txt` (root) | Top-level config: C++23, `bin/` output when top-level, MSVC export-all-symbols. Just `add_subdirectory(source)`. |
 | `source/libs/` | All reusable engine libraries. `libs/CMakeLists.txt` fetches shared deps (json, glm, uuid, nfd, VulkanEngine) and the managed-assembly helpers, then adds each lib. |
 | `source/libs/protocol/` | `ECS3DNetProtocol` (INTERFACE lib): `Protocol.h` — the wire format (`MessageType`, `Message`/`MessageReader` binary framing, `Role`, ports). Depended on by everything that touches the wire. |
-| `source/libs/data/` | `ECS3DData` — the foundation. Component **data** (Transform, RigidBody, ModelRenderer, LightRenderer, Colliders, Script), `Object`/`ObjectManager`, scenes, `AssetRegistry`, `ComponentRegistry`, `ProjectSerializer` (JSON file save/load) / `ProjectPacker` (binary wire snapshot), `Replication`. **No Vulkan, no ImGui.** |
+| `source/libs/data/` | `ECS3DData` — the foundation. Component **data** (Transform, RigidBody, ModelRenderer, LightRenderer, Colliders, Script, PlayerController, Camera), `Object`/`ObjectManager`, scenes, `AssetRegistry`, `ComponentRegistry`, `ProjectSerializer` (JSON file save/load) / `ProjectPacker` (binary wire snapshot), `Replication`. **No Vulkan, no ImGui.** |
 | `source/libs/sim/` | `ECS3DSim` — `PhysicsSystem` (integration, forces, response) and `CollisionSystem` (sweep-and-prune + GJK/EPA under `collisions/`). Operates on `ECS3DData` via accessors. OpenMP if available. |
-| `source/libs/render/` | `ECS3DRender` — `RenderSystem` (draws models/lights, pick feedback, selection highlight, collider gizmos), `GpuAssetCache` (UUID → `vke` GPU objects), `InputCapture`. Depends on `ECS3DData` + `VulkanEngine`. |
+| `source/libs/render/` | `ECS3DRender` — `RenderSystem` (draws models/lights, pick feedback, selection highlight, collider gizmos, and drives the `vke::Camera`/`Renderer3D` view from the scene's active `Camera` component), `GpuAssetCache` (UUID → `vke` GPU objects), `InputCapture`. Depends on `ECS3DData` + `VulkanEngine`. |
 | `source/libs/editor/` | `ECS3DEditorLib` — ImGui editing UI: `ComponentEditor` (per-type handlers), `ObjectGUIManager` (object tree + inspector), `AssetBrowserPanel`, `SaveUI`, `GuiComponents`. Depends on `ECS3DData` + `ECS3DRender` + `nfd`. |
 | `source/libs/net/` | `ECS3DNet` — `NetServer`/`NetClient`/`MessageQueue`/`ServerProcess` (C++), plus the `Transport/` C# assembly (`ECS3DNetTransport`, TCP + WebSocket backends). |
-| `source/libs/scripting/` | `ECS3DScripting` — `ScriptSystem`/`ScriptEngine` + native `bindings/` (Transform, RigidBody, InputUtils, World; `InputState`, `BindingContext`), plus the `ScriptBridge/` C# assembly and example `UserScripts/`. |
+| `source/libs/scripting/` | `ECS3DScripting` — `ScriptSystem`/`ScriptEngine` + native `bindings/` (Transform, RigidBody, InputUtils, World, Camera; `InputState`, `BindingContext`), plus the `ScriptBridge/` C# assembly and example `UserScripts/`. |
 | `source/libs/clrHost/` | `ECS3DClrHost` — `ManagedHost` boots CoreCLR and hands out managed statics as native fn ptrs. Owns the CMake helpers (`cmake/ECS3DManaged.cmake`, `FindDotnet.cmake`, `loadCS.cmake`). |
 | `source/apps/` | The executables. `apps/CMakeLists.txt` orders them (server first — client/editor depend on it). |
 | `source/apps/{server,client,editor}/` | The three C++ apps: a thin `main.cpp` (argv parsing) + a `*App` class. |
@@ -114,11 +114,11 @@ and `InputState` is keyed by that slot. A script reads *its own* player through 
 (`PlayerInput`), which resolves `object → PlayerController.playerSlot → InputState[slot]`; the global
 `InputUtils` stays a player-agnostic aggregate. `PlayerController` is an ordinary replicated data
 component (slot is editable + serialized), so possession is visible to the editor and to clients — the
-hook Phase 4's camera uses to pick "whose view". Mouse delta/scroll and key edges
+hook the camera uses to pick "whose view" (see Camera below). Mouse delta/scroll and key edges
 (`wasPressedThisTick`) accumulate between fixed ticks and are reset per tick by
 `InputState::clearMouseDeltas()`/`commitInputEdges()`. Forces
 requested from a script are buffered on the `RigidBody` data (pending-force queue) and drained by
-`PhysicsSystem`, keeping `scripting` independent of `sim`. Four conventions worth inheriting: (1) reaching
+`PhysicsSystem`, keeping `scripting` independent of `sim`. Five conventions worth inheriting: (1) reaching
 another object's component is a **`tryGet`** (`World.tryGetTransform(uuid, out t)` → false when
 absent/destroyed; never throws in the tick loop) — future component wrappers follow this; (2) a binding
 that mutates scene structure can't touch the net layer, so it **buffers the change on `BindingContext`**
@@ -131,7 +131,33 @@ pass — the same "buffer plain data, let the app carry it" shape as pending for
 `sim` system (`SceneQueries`: raycast/overlapSphere), and `ServerApp` injects its statics into
 `BindingContext` (`setRaycast`/`setOverlapSphere`) at startup; the `World` bindings call through them. The
 injected signatures use only shared types (`ObjectManager`/`glm`/`uuid`), so no library learns the other —
-the pattern to reuse for any future sim query exposed to scripts.
+the pattern to reuse for any future sim query exposed to scripts; (5) **a read-only script binding for
+data the object doesn't own outright** follows the same `Transform`/`RigidBody` shape even when nothing
+mutates it: `CameraBindings` (`getDirection`/`has`) lets `PlayerScript` read its own `Camera` component so
+movement can be relative to wherever the camera actually faces, degrading to the forward default
+`(0,0,-1)` when the object has none — the same "safe missing-component" convention as `tryGet`, just
+without the `tryGet` ceremony since `ScriptBase` always constructs one for the script's own object (like
+`transform`/`rigidBody`/`input`).
+
+**Camera.** `Camera` is a plain-field data component (`direction`, `fov`, `nearPlane`, `farPlane`,
+`active`) — position comes from the object's `Transform`, so only the *look* needs its own field.
+`RenderSystem::updateCamera` finds the active `Camera` (optionally restricted to one object), builds
+`lookAt(pos, pos + q·direction, worldUp)` — `q` is the object's orientation, so the camera turns as the
+object turns, but `worldUp` (not an orientation-derived up) keeps the horizon level — then disables
+`vke::Camera`'s free-fly and calls `Renderer3D::setCameraParameters`; no active camera re-enables free-fly.
+**The editor never calls `updateCamera`**, so its viewport keeps free-fly for free. **FOV/near/far are
+carried and editable but have no visible effect yet** — `vke`'s projection matrix is hardcoded
+(`RenderInfo::getProjectionMatrix`); a fix needs an upstream `VulkanRenderer` change (a projection setter
+alongside `setCameraParameters`), tracked as deliberately deferred in `ROADMAP.md`. A client picks its
+*own* camera via the player↔object association (`PlayerController.playerSlot` + a `Camera` on the same
+object) using a **nonce-over-broadcast** handshake: the client tags its `join` with a random nonce, the
+server echoes `(nonce, slot)` back over the existing broadcast (`NetServer` has no targeted-send path), and
+only the client whose nonce matches keeps it — chosen over adding a targeted-send ABI to the C# transport,
+which would have meant touching both backends for one bit of routing. `PlayerScript` mouse-look rotates the
+object's `Transform` from `input.mouseDelta()` while right-click is held (matching the free-fly camera's own
+gesture) and zeroes `RigidBody` angular velocity each tick so a collision-induced spin can't fight the look;
+movement is relative to the `Camera.direction` (via the binding above) rotated by that yaw, not a hardcoded
+forward axis.
 
 ## Development Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,13 @@ without the `tryGet` ceremony since `ScriptBase` always constructs one for the s
 `RenderSystem::updateCamera` finds the active `Camera` (optionally restricted to one object), builds
 `lookAt(pos, pos + q·direction, worldUp)` — `q` is the object's orientation, so the camera turns as the
 object turns, but `worldUp` (not an orientation-derived up) keeps the horizon level — then disables
-`vke::Camera`'s free-fly and calls `Renderer3D::setCameraParameters`; no active camera re-enables free-fly.
-**The editor never calls `updateCamera`**, so its viewport keeps free-fly for free. **FOV/near/far are
+`vke::Camera`'s free-fly and calls `Renderer3D::setCameraParameters`; no active camera re-enables free-fly
+(`RenderSystem::useFreeFlyCamera`, which also pushes the free-fly pose once on the handover — `render()`
+only pushes it while the scene view is focused, so without that the component camera's last pose lingers).
+The editor's **View** combo (Scene Status) picks what its viewport looks through: its own free-fly camera
+(the default) or any object in the scene carrying a `Camera`, which is how you see a client's view — a
+player camera is labelled with its `PlayerController` slot. A stale choice (object gone, `Camera` removed)
+falls back to free-fly. **FOV/near/far are
 carried and editable but have no visible effect yet** — `vke`'s projection matrix is hardcoded
 (`RenderInfo::getProjectionMatrix`); a fix needs an upstream `VulkanRenderer` change (a projection setter
 alongside `setCameraParameters`), tracked as deliberately deferred in `ROADMAP.md`. A client picks its
@@ -157,7 +162,13 @@ which would have meant touching both backends for one bit of routing. `PlayerScr
 object's `Transform` from `input.mouseDelta()` while right-click is held (matching the free-fly camera's own
 gesture) and zeroes `RigidBody` angular velocity each tick so a collision-induced spin can't fight the look;
 movement is relative to the `Camera.direction` (via the binding above) rotated by that yaw, not a hardcoded
-forward axis.
+forward axis. **The editor must not gate forwarded mouse input on `io.WantCaptureMouse`**: its 3D viewport
+*is* an ImGui window under the dockspace, so that flag is set whenever the cursor is over the scene, and
+gating on it silently swallows the right-drag mouse-look. `EditorApp::sendInput` instead forwards the mouse
+only while the viewport looks through a scene camera (in free-fly the right-drag belongs to the editor's own
+camera, so forwarding it too would turn the player at the same time) **and** `RenderingManager::isSceneFocused()`
+is true — the same signal `vke` gates its free-fly camera on. The keyboard still gates on
+`io.WantCaptureKeyboard`, which only trips for text input, so WASD reaches the game from either view.
 
 ## Development Principles
 
@@ -202,9 +213,9 @@ forward axis.
   render/editor — those invariants keep it headless.
 - Add dependencies only via `source/libs/CMakeLists.txt` `FetchContent`; register new files in the
   owning library's source list.
-- **The C++/CLR/Vulkan stack generally cannot be build-verified in the agent environment** (no MSVC/
-  Vulkan SDK/.NET). State clearly when a change is unverified and needs to be compiled on the user's
-  machine.
+- **Do not build-verify the C++/CLR/Vulkan stack — the developer does that.** Don't invoke `cmake --build`,
+  and never `dotnet build`/`publish` the C# projects directly. State clearly that a change is unverified
+  and needs to be compiled on the developer's machine.
 - Avoid speculative refactors. Keep changes scoped and incremental. Ask about lifetime/ownership,
   threading, and replication semantics rather than assuming.
 - Update this document when your understanding of the project meaningfully improves.

--- a/source/apps/client/ClientApp.cpp
+++ b/source/apps/client/ClientApp.cpp
@@ -7,6 +7,9 @@
 #include <scenes/SceneManager.h>
 #include <scenes/SceneAsset.h>
 #include <objects/ObjectManager.h>
+#include <objects/Object.h>
+#include <objects/components/PlayerController.h>
+#include <objects/components/Camera.h>
 #include <GpuAssetCache.h>
 #include <RenderSystem.h>
 #include <InputCapture.h>
@@ -16,6 +19,7 @@
 #include <VulkanEngine/VulkanEngine.h>
 #include <chrono>
 #include <iostream>
+#include <random>
 #include <thread>
 
 ClientApp::ClientApp(ConnectOptions options)
@@ -41,8 +45,13 @@ ClientApp::ClientApp(ConnectOptions options)
 
   connectToServer();
 
-  // Ask the server for the initial Snapshot.
-  const net::Message message(net::MessageType::join);
+  // A random per-session tag so the server can echo back this client's player slot (see handlePlayerSlot).
+  std::random_device rd;
+  m_joinNonce = (static_cast<uint64_t>(rd()) << 32) ^ rd();
+
+  // Ask the server for the initial Snapshot, tagged with our nonce so the reply's slot is identifiable.
+  net::Message message(net::MessageType::join);
+  message.write(m_joinNonce);
   m_netClient->send(message);
 }
 
@@ -189,9 +198,9 @@ void ClientApp::variableUpdate() const
   {
     m_renderSystem->variableUpdate(*scene->getObjectManager(), *m_assetCache);
 
-    // Render through the scene's active component Camera when one exists (Phase 4.2); falls back to the
-    // built-in free-fly camera otherwise. Phase 4.4 narrows this to the client's own player camera.
-    m_renderSystem->updateCamera(*scene->getObjectManager(), *m_assetCache);
+    // Render through this client's own player camera (the object with our PlayerController slot + a
+    // Camera); nullopt falls back to the scene's first active camera / free-fly (Phase 4.4).
+    m_renderSystem->updateCamera(*scene->getObjectManager(), *m_assetCache, resolvePlayerCamera());
   }
 
   m_renderer->render();
@@ -219,6 +228,10 @@ void ClientApp::applyMessage(const net::Message& message) const
 
     case net::MessageType::objectDestroyed:
       handleObjectDestroyed(message);
+      break;
+
+    case net::MessageType::playerSlot:
+      handlePlayerSlot(message);
       break;
 
     default: break;
@@ -271,4 +284,48 @@ void ClientApp::handleObjectDestroyed(const net::Message& message) const
   {
     replication::applyObjectDestroyed(*scene->getObjectManager(), message);
   }
+}
+
+void ClientApp::handlePlayerSlot(const net::Message& message) const
+{
+  // The server broadcasts every client's slot assignment; keep only the one tagged with our own nonce.
+  net::MessageReader reader(message);
+  const auto nonce = reader.read<uint64_t>();
+  const auto slot = reader.read<int32_t>();
+
+  if (nonce == m_joinNonce)
+  {
+    m_playerSlot = slot;
+  }
+}
+
+std::optional<uuids::uuid> ClientApp::resolvePlayerCamera() const
+{
+  if (m_playerSlot < 0)
+  {
+    return std::nullopt;
+  }
+
+  const auto scene = m_sceneManager->getCurrentScene();
+  if (!scene)
+  {
+    return std::nullopt;
+  }
+
+  // Our player object is the one whose PlayerController holds our slot; render through its Camera.
+  for (const auto& object : scene->getObjectManager()->getAllObjects())
+  {
+    const auto playerController = object->getComponent<PlayerController>(ComponentType::playerController);
+    if (!playerController || playerController->getPlayerSlot() != m_playerSlot)
+    {
+      continue;
+    }
+
+    if (object->getComponent<Camera>(ComponentType::camera))
+    {
+      return object->getUUID();
+    }
+  }
+
+  return std::nullopt;
 }

--- a/source/apps/client/ClientApp.cpp
+++ b/source/apps/client/ClientApp.cpp
@@ -188,6 +188,10 @@ void ClientApp::variableUpdate() const
   if (const auto scene = m_sceneManager->getCurrentScene())
   {
     m_renderSystem->variableUpdate(*scene->getObjectManager(), *m_assetCache);
+
+    // Render through the scene's active component Camera when one exists (Phase 4.2); falls back to the
+    // built-in free-fly camera otherwise. Phase 4.4 narrows this to the client's own player camera.
+    m_renderSystem->updateCamera(*scene->getObjectManager(), *m_assetCache);
   }
 
   m_renderer->render();

--- a/source/apps/client/ClientApp.h
+++ b/source/apps/client/ClientApp.h
@@ -4,7 +4,9 @@
 #include <Protocol.h>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
+#include <uuid.h>
 
 namespace vke {
   class VulkanEngine;
@@ -68,6 +70,13 @@ private:
   float m_lastMouseY = 0.0f;
   bool m_inputSent = false;
 
+  // A per-session random tag sent in join; the server echoes it back in a playerSlot message so this
+  // client can pick out its own slot assignment from the broadcast (Phase 4.4).
+  uint64_t m_joinNonce = 0;
+  // The player slot the server bound this client to (-1 until the playerSlot message arrives). Drives
+  // which object's Camera the client renders through. mutable: set from the const message-apply path.
+  mutable int32_t m_playerSlot = -1;
+
   void createRenderer();
 
   void connectToServer();
@@ -87,6 +96,13 @@ private:
   void handleObjectSpawned(const net::Message& message) const;
 
   void handleObjectDestroyed(const net::Message& message) const;
+
+  void handlePlayerSlot(const net::Message& message) const;
+
+  // The object this client should render through: the one carrying a PlayerController for this client's
+  // player slot and a Camera. nullopt when the slot is still unknown or no such camera exists — the
+  // caller then falls back to the scene's first active camera / free-fly (RenderSystem::updateCamera).
+  [[nodiscard]] std::optional<uuids::uuid> resolvePlayerCamera() const;
 };
 
 

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -277,9 +277,9 @@ void EditorApp::sendInput()
 {
   const auto& io = ImGui::GetIO();
 
-  // Don't let editor UI interaction drive the game: when ImGui wants the keyboard, report no keys; when
-  // it wants the mouse (hovering a panel), report no mouse. focused stays true (an unfocused window
-  // already reports no keys), so this view never disables another connected view's input.
+  // Don't let editor UI interaction drive the game: when ImGui wants the keyboard, report no keys.
+  // focused stays true (an unfocused window already reports no keys), so this view never disables
+  // another connected view's input.
   input::InputSnapshot snapshot = input::capture(*m_renderer);
 
   if (io.WantCaptureKeyboard)
@@ -287,7 +287,16 @@ void EditorApp::sendInput()
     snapshot.keys.clear();
   }
 
-  if (io.WantCaptureMouse)
+  // The mouse can't be gated on io.WantCaptureMouse: the 3D viewport is itself an ImGui window in the
+  // editor's dockspace, so that flag is set whenever the cursor is over it — which would swallow the
+  // right-drag mouse-look a script reads. Forward the mouse only while looking through a scene camera
+  // (in free-fly the right-drag belongs to the editor's own camera, so sending it too would turn the
+  // player at the same time) and while the scene view is focused, which is the signal vke's free-fly
+  // camera gates on and goes false as soon as a panel is clicked.
+  const bool mouseDrivesGame = m_viewCameraObject.has_value()
+                            && m_renderer->getRenderingManager()->isSceneFocused();
+
+  if (!mouseDrivesGame)
   {
     snapshot.mouseDeltaX = 0.0f;
     snapshot.mouseDeltaY = 0.0f;

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -25,6 +25,7 @@
 #include <components/ColliderEditor.h>
 #include <components/ScriptEditor.h>
 #include <components/PlayerControllerEditor.h>
+#include <components/CameraEditor.h>
 #include <NetClient.h>
 #include <ServerProcess.h>
 #include <ManagedHost.h>
@@ -348,6 +349,7 @@ void EditorApp::registerEditors() const
   registerColliderEditors(*m_componentEditor);
   registerScriptEditor(*m_componentEditor);
   registerPlayerControllerEditor(*m_componentEditor);
+  registerCameraEditor(*m_componentEditor);
 }
 
 void EditorApp::setupKeybinds()

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -18,6 +18,8 @@
 #include <AssetBrowserPanel.h>
 #include <SaveUI.h>
 #include <objects/components/Component.h>
+#include <objects/components/Camera.h>
+#include <objects/components/PlayerController.h>
 #include <components/TransformEditor.h>
 #include <components/RigidBodyEditor.h>
 #include <components/ModelRendererEditor.h>
@@ -42,6 +44,28 @@
 #include <optional>
 #include <random>
 #include <thread>
+
+namespace {
+  // How a camera reads in the editor's "View" combo: the owning object's name, the player slot when it's a
+  // client's player camera, and a cue when the Camera is inactive (RenderSystem only renders through active
+  // cameras, so selecting one shows the free-fly view instead).
+  std::string cameraLabel(const std::shared_ptr<Object>& object)
+  {
+    std::string label = object->getName();
+
+    if (const auto playerController = object->getComponent<PlayerController>(ComponentType::playerController))
+    {
+      label += " (Player " + std::to_string(playerController->getPlayerSlot()) + ")";
+    }
+
+    if (const auto camera = object->getComponent<Camera>(ComponentType::camera); camera && !camera->isActive())
+    {
+      label += " - inactive";
+    }
+
+    return label;
+  }
+}
 
 EditorApp::EditorApp(LaunchOptions options)
   : m_options(std::move(options)),
@@ -620,7 +644,7 @@ void EditorApp::displayMessageLog()
   ImGui::End();
 }
 
-void EditorApp::displaySceneStatus() const
+void EditorApp::displaySceneStatus()
 {
   constexpr int sceneStatusButtonWidth = 125;
 
@@ -681,6 +705,8 @@ void EditorApp::displaySceneStatus() const
   }
   ImGui::EndDisabled();
 
+  displayCameraSelector();
+
   // Status readout (divider + dot/label + scene name), right-aligned to the panel edge so the play
   // buttons stay put on the left regardless of the readout's width.
   const char* label = m_sceneStatus == SceneStatus::running ? "Running"
@@ -734,11 +760,91 @@ void EditorApp::displaySceneStatus() const
   ImGui::End();
 }
 
-void EditorApp::variableUpdate() const
+void EditorApp::displayCameraSelector()
 {
-  if (const auto scene = m_sceneManager->getCurrentScene())
+  constexpr auto freeFlyLabel = "Editor Camera";
+
+  const auto scene = m_sceneManager->getCurrentScene();
+  const auto objectManager = scene ? scene->getObjectManager().get() : nullptr;
+
+  // A view choice, not a scene edit, so this stays enabled on a read-only server.
+  std::string preview = freeFlyLabel;
+  if (objectManager && m_viewCameraObject)
   {
-    m_renderSystem->variableUpdate(*scene->getObjectManager(), *m_assetCache, m_objectGUIManager->getHighlightUUID());
+    if (const auto object = objectManager->getObjectByUUID(*m_viewCameraObject))
+    {
+      preview = cameraLabel(object);
+    }
+  }
+
+  ImGui::SameLine(0.0f, 18.0f);
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextColored(theme::t2, "%s", "View");
+  ImGui::SameLine();
+
+  ImGui::SetNextItemWidth(200.0f);
+  if (ImGui::BeginCombo("##ViewCamera", preview.c_str()))
+  {
+    if (ImGui::Selectable(freeFlyLabel, !m_viewCameraObject))
+    {
+      m_viewCameraObject.reset();
+    }
+
+    if (objectManager)
+    {
+      for (const auto& object : objectManager->getAllObjects())
+      {
+        if (!object->getComponent<Camera>(ComponentType::camera))
+        {
+          continue;
+        }
+
+        const auto uuid = object->getUUID();
+
+        // Objects can share a name, so the uuid disambiguates the ImGui id.
+        const std::string label = cameraLabel(object) + "##" + uuids::to_string(uuid);
+
+        if (ImGui::Selectable(label.c_str(), m_viewCameraObject == uuid))
+        {
+          m_viewCameraObject = uuid;
+        }
+      }
+    }
+
+    ImGui::EndCombo();
+  }
+}
+
+void EditorApp::variableUpdate()
+{
+  const auto scene = m_sceneManager->getCurrentScene();
+  const auto objectManager = scene ? scene->getObjectManager().get() : nullptr;
+
+  if (objectManager)
+  {
+    m_renderSystem->variableUpdate(*objectManager, *m_assetCache, m_objectGUIManager->getHighlightUUID());
+  }
+
+  // Drop a stale choice (the object left the scene, or lost its Camera) rather than freezing the viewport
+  // on that camera's last pose.
+  if (objectManager && m_viewCameraObject)
+  {
+    const auto object = objectManager->getObjectByUUID(*m_viewCameraObject);
+
+    if (!object || !object->getComponent<Camera>(ComponentType::camera))
+    {
+      m_viewCameraObject.reset();
+    }
+  }
+
+  // Look through the selected scene camera, or hand the viewport back to the editor's free-fly camera.
+  if (objectManager && m_viewCameraObject)
+  {
+    m_renderSystem->updateCamera(*objectManager, *m_assetCache, m_viewCameraObject);
+  }
+  else
+  {
+    m_renderSystem->useFreeFlyCamera(*m_assetCache);
   }
 
   m_renderer->render();

--- a/source/apps/editor/EditorApp.h
+++ b/source/apps/editor/EditorApp.h
@@ -4,8 +4,10 @@
 #include <VulkanEngine/components/window/Window.h>
 #include <Protocol.h>
 #include <scenes/SceneManager.h>
+#include <uuid.h>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -94,6 +96,11 @@ private:
 
   SceneStatus m_sceneStatus = SceneStatus::running;
 
+  // The object whose Camera component the viewport looks through ("View" combo in Scene Status), letting
+  // the editor see what a client sees. nullopt = the editor's own free-fly camera. Purely local: it's a
+  // view choice, never replicated. Cleared when the chosen object leaves the scene or loses its Camera.
+  std::optional<uuids::uuid> m_viewCameraObject;
+
   // Only resend input when it changes (see ClientApp): keeps an unfocused editor from clobbering a
   // focused client's keys on the shared server-side InputState.
   std::vector<int> m_lastInputKeys;
@@ -142,13 +149,17 @@ private:
 
   void displayMenuBar() const;
 
-  void displaySceneStatus() const;
+  void displaySceneStatus();
+
+  // The "View" combo: the editor's free-fly camera, or any Camera in the scene (a client's player camera
+  // is labelled with its slot).
+  void displayCameraSelector();
 
   void updateDockSpace() const;
 
   void displayMessageLog();
 
-  void variableUpdate() const;
+  void variableUpdate();
 
   // The editor spawns a child ECS3DServer (ServerProcess) in edit mode and connects over localhost as
   // Role::editor, authorized by the --token it shares with that server at the handshake; edits then

--- a/source/apps/server/DefaultProject.cpp
+++ b/source/apps/server/DefaultProject.cpp
@@ -1,6 +1,7 @@
 #include "DefaultProject.h"
 #include <nlohmann/json.hpp>
 #include <glm/vec3.hpp>
+#include <glm/geometric.hpp>
 #include <random>
 #include <string>
 #include <uuid.h>
@@ -99,6 +100,18 @@ json playerController(const int slot = 0)
   };
 }
 
+json camera(const glm::vec3& direction = glm::vec3(0, 0, -1))
+{
+  return {
+    { "type", "Camera" },
+    { "direction", vec(direction) },
+    { "fov", 45.0 },
+    { "nearPlane", 0.1 },
+    { "farPlane", 1000.0 },
+    { "active", true }
+  };
+}
+
 json makeObject(const std::string& name, json components, json scripts = json::array())
 {
   return {
@@ -145,14 +158,18 @@ json sphere(const glm::vec3& position, const glm::vec3& scale = glm::vec3(1))
   }));
 }
 
-json player(const glm::vec3& position, const int slot = 0)
+json player(const glm::vec3& position, const int slot = 0,
+            const glm::vec3& cameraDirection = glm::vec3(0, 0, -1))
 {
-  return makeObject("Player", json::array({
+  // The camera's initial facing is set on the Camera component itself (cameraDirection), independent of the
+  // player model's orientation.
+  return makeObject("Player " + std::to_string(slot), json::array({
     transform(position),
     modelRenderer(playerModel, whiteTexture, whiteTexture),
     rigidBody(),
     sphereCollider(),
-    playerController(slot)
+    playerController(slot),
+    camera(cameraDirection)
   }), json::array({
     {
       { "type", "Script" },
@@ -200,7 +217,10 @@ json buildScene1()
     sphere({ 2, 0, 0 }),
     sphere({ 0, 2, 0 }),
     sphere({ 0, -2, 2 }),
-    player({ 5, 0, 5 })
+    // Two players so an editor (slot 0) and a client (slot 1) each have their own camera POV when testing.
+    // Each camera's direction aims back toward the scene (origin) from opposite sides.
+    player({ 5, 0, 5 }, 0, glm::normalize(glm::vec3(-5, 0, -5))),
+    player({ -5, 0, 5 }, 1, glm::normalize(glm::vec3(5, 0, -5)))
   });
 }
 
@@ -215,7 +235,7 @@ json buildScene2()
     rigidBlock({ -18, -5, 0 }, { 10, 1, 10 }, { 0, 0, -30 }),
     block({ -22, 10, -3 }),
     sphere({ 2, 0, 3 }),
-    player({ 5, 0, 5 })
+    player({ 5, 0, 5 }, 0, glm::normalize(glm::vec3(-5, 0, -5)))
   });
 }
 

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -298,7 +298,22 @@ void ServerApp::handleJoin(const net::Message& message, const int32_t senderId)
   // server is editable, then send the full project/scene as a Snapshot. Record that a connection has been
   // seen so an ephemeral server (exitWhenEmpty) can later exit when the last one drops.
   m_hasConnected = true;
-  assignPlayerSlot(senderId);
+  const int32_t slot = assignPlayerSlot(senderId);
+
+  // If the joining client tagged its request with a nonce (players do; the editor sends none), tell it
+  // which player slot it was bound to so it can render through that player's camera (Phase 4.4). Broadcast
+  // + nonce correlation avoids a per-connection send path: every client hears it, but only the one whose
+  // join nonce matches keeps it. The remaining() guard keeps an older/nonce-less client working.
+  net::MessageReader reader(message);
+  if (reader.remaining() >= sizeof(uint64_t))
+  {
+    const auto nonce = reader.read<uint64_t>();
+    net::Message reply(net::MessageType::playerSlot);
+    reply.write(nonce);
+    reply.write(slot);
+    m_netServer->broadcast(reply);
+  }
+
   broadcastEditStatus();
   broadcastSnapshot();
 }

--- a/source/libs/data/CMakeLists.txt
+++ b/source/libs/data/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(${PROJECT_NAME}
   objects/components/Script.h
   objects/components/PlayerController.cpp
   objects/components/PlayerController.h
+  objects/components/Camera.cpp
+  objects/components/Camera.h
   objects/components/ModelRenderer.cpp
   objects/components/ModelRenderer.h
   objects/components/LightRenderer.cpp

--- a/source/libs/data/ComponentRegistration.cpp
+++ b/source/libs/data/ComponentRegistration.cpp
@@ -8,6 +8,7 @@
 #include "objects/components/collisions/SphereCollider.h"
 #include "objects/components/Script.h"
 #include "objects/components/PlayerController.h"
+#include "objects/components/Camera.h"
 #include <memory>
 
 void registerDataComponents(ComponentRegistry& componentRegistry)
@@ -31,4 +32,7 @@ void registerDataComponents(ComponentRegistry& componentRegistry)
 
   // Player↔object association (Phase 3.2): marks an object as owned by a player slot.
   componentRegistry.registerComponent("PlayerController", [] { return std::make_shared<PlayerController>(); });
+
+  // A view the renderer can look through (Phase 4).
+  componentRegistry.registerComponent("Camera", [] { return std::make_shared<Camera>(); });
 }

--- a/source/libs/data/objects/components/Camera.cpp
+++ b/source/libs/data/objects/components/Camera.cpp
@@ -6,6 +6,16 @@ Camera::Camera()
   : Component(ComponentType::camera)
 {}
 
+glm::vec3 Camera::getDirection() const
+{
+  return m_direction;
+}
+
+void Camera::setDirection(const glm::vec3& direction)
+{
+  m_direction = direction;
+}
+
 float Camera::getFov() const
 {
   return m_fov;
@@ -50,6 +60,7 @@ nlohmann::json Camera::serialize()
 {
   return {
     { "type", "Camera" },
+    { "direction", { m_direction.x, m_direction.y, m_direction.z } },
     { "fov", m_fov },
     { "nearPlane", m_nearPlane },
     { "farPlane", m_farPlane },
@@ -60,6 +71,11 @@ nlohmann::json Camera::serialize()
 void Camera::loadFromJSON(const nlohmann::json& componentData)
 {
   // value(...) so an older scene without a field defaults cleanly.
+  if (const auto it = componentData.find("direction"); it != componentData.end() && it->size() == 3)
+  {
+    m_direction = glm::vec3(it->at(0), it->at(1), it->at(2));
+  }
+
   m_fov = componentData.value("fov", 45.0f);
   m_nearPlane = componentData.value("nearPlane", 0.1f);
   m_farPlane = componentData.value("farPlane", 1000.0f);
@@ -70,6 +86,7 @@ void Camera::pack(net::Message& message) const
 {
   message.write(ComponentType::camera);
 
+  message.write(m_direction);
   message.write(m_fov);
   message.write(m_nearPlane);
   message.write(m_farPlane);
@@ -78,6 +95,7 @@ void Camera::pack(net::Message& message) const
 
 void Camera::unpack(net::MessageReader& messageReader)
 {
+  m_direction = messageReader.read<glm::vec3>();
   m_fov = messageReader.read<float>();
   m_nearPlane = messageReader.read<float>();
   m_farPlane = messageReader.read<float>();

--- a/source/libs/data/objects/components/Camera.cpp
+++ b/source/libs/data/objects/components/Camera.cpp
@@ -1,0 +1,85 @@
+#include "Camera.h"
+#include <nlohmann/json.hpp>
+#include <Protocol.h>
+
+Camera::Camera()
+  : Component(ComponentType::camera)
+{}
+
+float Camera::getFov() const
+{
+  return m_fov;
+}
+
+void Camera::setFov(const float fov)
+{
+  m_fov = fov;
+}
+
+float Camera::getNearPlane() const
+{
+  return m_nearPlane;
+}
+
+void Camera::setNearPlane(const float nearPlane)
+{
+  m_nearPlane = nearPlane;
+}
+
+float Camera::getFarPlane() const
+{
+  return m_farPlane;
+}
+
+void Camera::setFarPlane(const float farPlane)
+{
+  m_farPlane = farPlane;
+}
+
+bool Camera::isActive() const
+{
+  return m_active;
+}
+
+void Camera::setActive(const bool active)
+{
+  m_active = active;
+}
+
+nlohmann::json Camera::serialize()
+{
+  return {
+    { "type", "Camera" },
+    { "fov", m_fov },
+    { "nearPlane", m_nearPlane },
+    { "farPlane", m_farPlane },
+    { "active", m_active }
+  };
+}
+
+void Camera::loadFromJSON(const nlohmann::json& componentData)
+{
+  // value(...) so an older scene without a field defaults cleanly.
+  m_fov = componentData.value("fov", 45.0f);
+  m_nearPlane = componentData.value("nearPlane", 0.1f);
+  m_farPlane = componentData.value("farPlane", 1000.0f);
+  m_active = componentData.value("active", true);
+}
+
+void Camera::pack(net::Message& message) const
+{
+  message.write(ComponentType::camera);
+
+  message.write(m_fov);
+  message.write(m_nearPlane);
+  message.write(m_farPlane);
+  message.write(m_active);
+}
+
+void Camera::unpack(net::MessageReader& messageReader)
+{
+  m_fov = messageReader.read<float>();
+  m_nearPlane = messageReader.read<float>();
+  m_farPlane = messageReader.read<float>();
+  m_active = messageReader.read<bool>();
+}

--- a/source/libs/data/objects/components/Camera.h
+++ b/source/libs/data/objects/components/Camera.h
@@ -1,0 +1,43 @@
+#ifndef CAMERA_H
+#define CAMERA_H
+
+#include "Component.h"
+
+// A view the renderer can look through (Phase 4). The camera's pose comes from its object's Transform
+// (scripts already drive transforms), so this component only carries projection params + an active flag.
+// RenderSystem finds the active camera each frame and pushes its pose/params into the vke renderer; a
+// client picks which camera to render through via the player↔object association (PlayerController).
+class Camera final : public Component {
+public:
+  Camera();
+
+  [[nodiscard]] float getFov() const;
+  void setFov(float fov);
+
+  [[nodiscard]] float getNearPlane() const;
+  void setNearPlane(float nearPlane);
+
+  [[nodiscard]] float getFarPlane() const;
+  void setFarPlane(float farPlane);
+
+  [[nodiscard]] bool isActive() const;
+  void setActive(bool active);
+
+  [[nodiscard]] nlohmann::json serialize() override;
+
+  void loadFromJSON(const nlohmann::json& componentData) override;
+
+  void pack(net::Message& message) const override;
+
+  void unpack(net::MessageReader& messageReader) override;
+
+private:
+  float m_fov = 45.0f;
+  float m_nearPlane = 0.1f;
+  float m_farPlane = 1000.0f;
+  bool m_active = true;
+};
+
+
+
+#endif //CAMERA_H

--- a/source/libs/data/objects/components/Camera.h
+++ b/source/libs/data/objects/components/Camera.h
@@ -2,14 +2,19 @@
 #define CAMERA_H
 
 #include "Component.h"
+#include <glm/vec3.hpp>
 
-// A view the renderer can look through (Phase 4). The camera's pose comes from its object's Transform
-// (scripts already drive transforms), so this component only carries projection params + an active flag.
-// RenderSystem finds the active camera each frame and pushes its pose/params into the vke renderer; a
-// client picks which camera to render through via the player↔object association (PlayerController).
+// A view the renderer can look through (Phase 4). Position comes from the object's Transform; the facing
+// is this component's own `direction`, applied relative to the Transform rotation (so the camera turns as
+// the object turns, but its aim is editable independent of the object's/model's orientation). RenderSystem
+// finds the active camera each frame and pushes its pose/params into the vke renderer; a client picks which
+// camera to render through via the player↔object association (PlayerController).
 class Camera final : public Component {
 public:
   Camera();
+
+  [[nodiscard]] glm::vec3 getDirection() const;
+  void setDirection(const glm::vec3& direction);
 
   [[nodiscard]] float getFov() const;
   void setFov(float fov);
@@ -32,6 +37,8 @@ public:
   void unpack(net::MessageReader& messageReader) override;
 
 private:
+  // Local look direction (object space); (0,0,-1) faces the object's forward, matching model orientation.
+  glm::vec3 m_direction = glm::vec3(0.0f, 0.0f, -1.0f);
   float m_fov = 45.0f;
   float m_nearPlane = 0.1f;
   float m_farPlane = 1000.0f;

--- a/source/libs/data/objects/components/Component.h
+++ b/source/libs/data/objects/components/Component.h
@@ -23,7 +23,8 @@ enum class ComponentType {
   SubComponentType_boxCollider,
   SubComponentType_sphereCollider,
   script,
-  playerController // appended last: the packed value is the wire discriminator, so new types go at the end
+  playerController,
+  camera // appended last: the packed value is the wire discriminator, so new types go at the end
 };
 
 const std::unordered_map<ComponentType, std::string> componentTypeToString {
@@ -34,7 +35,8 @@ const std::unordered_map<ComponentType, std::string> componentTypeToString {
   {ComponentType::SubComponentType_sphereCollider, "Sphere Collider"},
   {ComponentType::lightRenderer, "Light Renderer"},
   {ComponentType::script, "Script"},
-  {ComponentType::playerController, "Player Controller"}
+  {ComponentType::playerController, "Player Controller"},
+  {ComponentType::camera, "Camera"}
 };
 
 const std::unordered_map<ComponentType, ComponentType> subComponentTypeToParent {
@@ -53,7 +55,8 @@ const std::unordered_map<ComponentType, std::string> componentTypeToRegistryKey 
   {ComponentType::SubComponentType_boxCollider, "Box"},
   {ComponentType::SubComponentType_sphereCollider, "Sphere"},
   {ComponentType::script, "Script"},
-  {ComponentType::playerController, "PlayerController"}
+  {ComponentType::playerController, "PlayerController"},
+  {ComponentType::camera, "Camera"}
 };
 
 class ComponentVariableBase {

--- a/source/libs/editor/CMakeLists.txt
+++ b/source/libs/editor/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(${PROJECT_NAME}
   components/ScriptEditor.h
   components/PlayerControllerEditor.cpp
   components/PlayerControllerEditor.h
+  components/CameraEditor.cpp
+  components/CameraEditor.h
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/source/libs/editor/ObjectGUIManager.cpp
+++ b/source/libs/editor/ObjectGUIManager.cpp
@@ -18,13 +18,14 @@ namespace {
   // checkType is the ComponentType whose presence on the object hides this entry.
   // Transform is omitted (every object already has one); scripts attach via drag & drop only.
   struct AddableComponent { const char* label; const char* key; ComponentType checkType; gc::SecIcon icon; };
-  constexpr std::array<AddableComponent, 6> addableComponents {{
+  constexpr std::array<AddableComponent, 7> addableComponents {{
     { "Rigid Body",        "RigidBody",        ComponentType::rigidBody,        gc::SecIcon::rigid    },
     { "Model Renderer",    "ModelRenderer",    ComponentType::modelRenderer,    gc::SecIcon::image    },
     { "Light Renderer",    "LightRenderer",    ComponentType::lightRenderer,    gc::SecIcon::light    },
     { "Box Collider",      "Box",              ComponentType::collider,         gc::SecIcon::collider },
     { "Sphere Collider",   "Sphere",           ComponentType::collider,         gc::SecIcon::sphere   },
-    { "Player Controller", "PlayerController", ComponentType::playerController, gc::SecIcon::none     }
+    { "Player Controller", "PlayerController", ComponentType::playerController, gc::SecIcon::none     },
+    { "Camera",            "Camera",           ComponentType::camera,           gc::SecIcon::none     }
   }};
 
   // Heuristic icon for an object derived from its components (the mockup shows a per-object glyph).

--- a/source/libs/editor/components/CameraEditor.cpp
+++ b/source/libs/editor/components/CameraEditor.cpp
@@ -2,6 +2,7 @@
 #include "../ComponentEditor.h"
 #include "../GuiComponents.h"
 #include <objects/components/Camera.h>
+#include <glm/vec3.hpp>
 #include <imgui.h>
 #include <algorithm>
 #include <memory>
@@ -21,6 +22,7 @@ void registerCameraEditor(ComponentEditor& componentEditor)
     if (ComponentEditor::displayHeader(component))
     {
       bool active = camera->isActive();
+      glm::vec3 direction = camera->getDirection();
       float fov = camera->getFov();
       float nearPlane = camera->getNearPlane();
       float farPlane = camera->getFarPlane();
@@ -31,6 +33,13 @@ void registerCameraEditor(ComponentEditor& componentEditor)
       if (gc::accentCheckbox("Active", &active))
       {
         camera->setActive(active);
+        edited = true;
+      }
+
+      // The direction the camera looks, relative to the object's rotation. (0,0,-1) = the object's forward.
+      if (gc::xyzGuiBoxed("Direction", &direction.x, &direction.y, &direction.z, 0.01f))
+      {
+        camera->setDirection(direction);
         edited = true;
       }
 

--- a/source/libs/editor/components/CameraEditor.cpp
+++ b/source/libs/editor/components/CameraEditor.cpp
@@ -1,0 +1,58 @@
+#include "CameraEditor.h"
+#include "../ComponentEditor.h"
+#include "../GuiComponents.h"
+#include <objects/components/Camera.h>
+#include <imgui.h>
+#include <algorithm>
+#include <memory>
+
+void registerCameraEditor(ComponentEditor& componentEditor)
+{
+  // Keyed by the componentTypeToString display name ("Camera") ObjectGUIManager looks the handler up by.
+  componentEditor.registerHandler("Camera", [](const std::shared_ptr<Component>& component) -> bool {
+    const auto camera = std::dynamic_pointer_cast<Camera>(component);
+    if (!camera)
+    {
+      return false;
+    }
+
+    bool edited = false;
+
+    if (ComponentEditor::displayHeader(component))
+    {
+      bool active = camera->isActive();
+      float fov = camera->getFov();
+      float nearPlane = camera->getNearPlane();
+      float farPlane = camera->getFarPlane();
+
+      // Only an active camera is picked up by RenderSystem::updateCamera. Note: fov/near/far are carried
+      // and serialized, but the engine's projection is currently hardcoded, so editing them has no visible
+      // effect until VulkanEngine exposes a projection setter (see ROADMAP 4.2).
+      if (gc::accentCheckbox("Active", &active))
+      {
+        camera->setActive(active);
+        edited = true;
+      }
+
+      if (gc::accentSlider("FOV", &fov, 1.0f, 179.0f))
+      {
+        camera->setFov(fov);
+        edited = true;
+      }
+
+      if (gc::labeledDrag("Near Plane", &nearPlane, 0.01f))
+      {
+        camera->setNearPlane(std::max(nearPlane, 0.001f));
+        edited = true;
+      }
+
+      if (gc::labeledDrag("Far Plane", &farPlane, 1.0f))
+      {
+        camera->setFarPlane(std::max(farPlane, nearPlane + 0.001f));
+        edited = true;
+      }
+    }
+
+    return edited;
+  });
+}

--- a/source/libs/editor/components/CameraEditor.h
+++ b/source/libs/editor/components/CameraEditor.h
@@ -1,0 +1,10 @@
+#ifndef CAMERAEDITOR_H
+#define CAMERAEDITOR_H
+
+class ComponentEditor;
+
+void registerCameraEditor(ComponentEditor& componentEditor);
+
+
+
+#endif //CAMERAEDITOR_H

--- a/source/libs/protocol/Protocol.h
+++ b/source/libs/protocol/Protocol.h
@@ -33,7 +33,10 @@ enum class MessageType : uint8_t {
   editStatus,    // server -> client: whether this server accepts edits ({ editable: bool }); sent on join
   sceneStatus,   // server -> client: current scene lifecycle state ({ status: "running"|"paused"|"stopped" })
   objectSpawned, // server -> client: one object created at runtime (Object::pack); spliced into the scene
-  objectDestroyed // server -> client: uuid of an object removed at runtime; the client drops it from the scene
+  objectDestroyed, // server -> client: uuid of an object removed at runtime; the client drops it from the scene
+  playerSlot     // server -> all: (nonce uint64, slot int32) — the player slot bound to the client whose
+                 // join carried this nonce. Broadcast + nonce correlation (no per-connection send path):
+                 // every client hears it, only the one whose join nonce matches keeps it (Phase 4.4).
   // editComponent/sceneEdit/sceneControl/loadProject/addAsset are the editor's mutation path; the server
   // only honors them from a connection it authorized as Role::editor at the transport handshake (which
   // carries role + token out of band, ahead of any message here), and only on an edit-mode server. An

--- a/source/libs/render/RenderSystem.cpp
+++ b/source/libs/render/RenderSystem.cpp
@@ -10,6 +10,8 @@
 #include <objects/components/collisions/BoxCollider.h>
 #include <objects/components/collisions/SphereCollider.h>
 #include <glm/vec3.hpp>
+#include <glm/common.hpp>
+#include <glm/geometric.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <VulkanEngine/VulkanEngine.h>
@@ -162,12 +164,26 @@ void RenderSystem::updateCamera(const ObjectManager& objectManager, GpuAssetCach
       continue;
     }
 
-    // Pose comes from the object's Transform. A zero rotation faces -Z (matching object orientation and
-    // the vke camera's default forward); the quaternion also carries roll into the up vector.
+    // Position comes from the Transform; facing is the Camera's own direction, rotated by the object's
+    // orientation so the camera turns as the object turns. World-up (not an orientation-derived up) keeps
+    // the horizon level and avoids the roll/inversion the euler-quaternion up produced.
     const glm::vec3 position = transform->getPosition();
     const glm::quat orientation(glm::radians(transform->getRotation()));
-    const glm::vec3 forward = orientation * glm::vec3(0.0f, 0.0f, -1.0f);
-    const glm::vec3 up = orientation * glm::vec3(0.0f, 1.0f, 0.0f);
+
+    glm::vec3 forward = orientation * camera->getDirection();
+    if (glm::length(forward) < 1e-6f)
+    {
+      forward = glm::vec3(0.0f, 0.0f, -1.0f); // guard an un-set (zero) direction
+    }
+    forward = glm::normalize(forward);
+
+    // lookAt degenerates when the view direction is parallel to up (looking straight up/down); fall back to
+    // a different reference axis so the matrix stays finite.
+    glm::vec3 up(0.0f, 1.0f, 0.0f);
+    if (glm::abs(glm::dot(forward, up)) > 0.9999f)
+    {
+      up = glm::vec3(0.0f, 0.0f, 1.0f);
+    }
 
     const glm::mat4 viewMatrix = lookAt(position, position + forward, up);
 

--- a/source/libs/render/RenderSystem.cpp
+++ b/source/libs/render/RenderSystem.cpp
@@ -6,10 +6,14 @@
 #include <objects/components/Transform.h>
 #include <objects/components/ModelRenderer.h>
 #include <objects/components/LightRenderer.h>
+#include <objects/components/Camera.h>
 #include <objects/components/collisions/BoxCollider.h>
 #include <objects/components/collisions/SphereCollider.h>
 #include <glm/vec3.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
 #include <VulkanEngine/VulkanEngine.h>
+#include <VulkanEngine/components/camera/Camera.h>
 #include <VulkanEngine/components/assets/objects/RenderObject.h>
 #include <VulkanEngine/components/lighting/LightingManager.h>
 #include <VulkanEngine/components/lighting/lights/PointLight.h>
@@ -129,6 +133,52 @@ void RenderSystem::variableUpdate(const ObjectManager& objectManager, GpuAssetCa
       }
     }
   }
+}
+
+void RenderSystem::updateCamera(const ObjectManager& objectManager, GpuAssetCache& assetCache,
+                                const std::optional<uuids::uuid>& cameraObject)
+{
+  const auto renderer = assetCache.getRenderer();
+
+  for (const auto& object : objectManager.getAllObjects())
+  {
+    // When a specific camera object is requested (a client's own player camera), skip the rest.
+    if (cameraObject && object->getUUID() != *cameraObject)
+    {
+      continue;
+    }
+
+    const auto camera = object->getComponent<Camera>(ComponentType::camera);
+
+    if (!camera || !camera->isActive())
+    {
+      continue;
+    }
+
+    const auto transform = object->getComponent<Transform>(ComponentType::transform);
+
+    if (!transform)
+    {
+      continue;
+    }
+
+    // Pose comes from the object's Transform. A zero rotation faces -Z (matching object orientation and
+    // the vke camera's default forward); the quaternion also carries roll into the up vector.
+    const glm::vec3 position = transform->getPosition();
+    const glm::quat orientation(glm::radians(transform->getRotation()));
+    const glm::vec3 forward = orientation * glm::vec3(0.0f, 0.0f, -1.0f);
+    const glm::vec3 up = orientation * glm::vec3(0.0f, 1.0f, 0.0f);
+
+    const glm::mat4 viewMatrix = lookAt(position, position + forward, up);
+
+    // Take over from the built-in free-fly camera (render() skips it while disabled, so this pose sticks).
+    renderer->getCamera()->disable();
+    renderer->getRenderingManager()->getRenderer3D()->setCameraParameters(position, viewMatrix);
+    return;
+  }
+
+  // No active component camera in the scene — hand control back to the built-in free-fly camera.
+  renderer->getCamera()->enable();
 }
 
 bool RenderSystem::isSelected(const uuids::uuid& uuid) const

--- a/source/libs/render/RenderSystem.cpp
+++ b/source/libs/render/RenderSystem.cpp
@@ -24,6 +24,24 @@
 #include <VulkanEngine/components/renderingManager/RenderingManager.h>
 #include <VulkanEngine/components/renderingManager/renderer3D/Renderer3D.h>
 
+namespace {
+  // Hand the viewport back to the built-in free-fly camera. render() only pushes the free-fly pose while
+  // the scene view is focused, so push it once here too: otherwise the component camera's last pose would
+  // linger until the user happens to focus the viewport.
+  void enableFreeFlyCamera(const std::shared_ptr<vke::VulkanEngine>& renderer)
+  {
+    const auto camera = renderer->getCamera();
+
+    if (camera->isEnabled())
+    {
+      return;
+    }
+
+    camera->enable();
+    renderer->getRenderingManager()->getRenderer3D()->setCameraParameters(camera->getPosition(), camera->getViewMatrix());
+  }
+}
+
 void RenderSystem::variableUpdate(const ObjectManager& objectManager, GpuAssetCache& assetCache,
                                  const std::optional<uuids::uuid>& highlightUUID)
 {
@@ -194,7 +212,12 @@ void RenderSystem::updateCamera(const ObjectManager& objectManager, GpuAssetCach
   }
 
   // No active component camera in the scene — hand control back to the built-in free-fly camera.
-  renderer->getCamera()->enable();
+  enableFreeFlyCamera(renderer);
+}
+
+void RenderSystem::useFreeFlyCamera(GpuAssetCache& assetCache) const
+{
+  enableFreeFlyCamera(assetCache.getRenderer());
 }
 
 bool RenderSystem::isSelected(const uuids::uuid& uuid) const

--- a/source/libs/render/RenderSystem.h
+++ b/source/libs/render/RenderSystem.h
@@ -24,11 +24,16 @@ public:
   // Drives the vke camera from a component Camera (Phase 4). Finds the active Camera object, builds a
   // view matrix from its Transform pose, disables the built-in free-fly camera, and pushes the pose into
   // the renderer. Falls back to (re-enabling) the free-fly camera when no active camera exists. The
-  // client calls this each frame; the editor never does, so its editing viewport keeps free-fly control.
+  // client calls this each frame; the editor calls it only while its viewport is looking through a scene
+  // camera, and calls useFreeFlyCamera() otherwise.
   // cameraObject optionally restricts the search to one object (Phase 4.4 — a client's own player camera);
   // nullopt means "first active camera in the scene".
   void updateCamera(const ObjectManager& objectManager, GpuAssetCache& assetCache,
                     const std::optional<uuids::uuid>& cameraObject = std::nullopt);
+
+  // Hands the viewport back to the built-in free-fly camera (the editor's default view). Idempotent, so
+  // it's safe to call every frame.
+  void useFreeFlyCamera(GpuAssetCache& assetCache) const;
 
   // True for the object under the cursor; the editor reads it to drive Ctrl-click selection.
   [[nodiscard]] bool isSelected(const uuids::uuid& uuid) const;

--- a/source/libs/render/RenderSystem.h
+++ b/source/libs/render/RenderSystem.h
@@ -21,6 +21,15 @@ public:
   void variableUpdate(const ObjectManager& objectManager, GpuAssetCache& assetCache,
                       const std::optional<uuids::uuid>& highlightUUID = std::nullopt);
 
+  // Drives the vke camera from a component Camera (Phase 4). Finds the active Camera object, builds a
+  // view matrix from its Transform pose, disables the built-in free-fly camera, and pushes the pose into
+  // the renderer. Falls back to (re-enabling) the free-fly camera when no active camera exists. The
+  // client calls this each frame; the editor never does, so its editing viewport keeps free-fly control.
+  // cameraObject optionally restricts the search to one object (Phase 4.4 — a client's own player camera);
+  // nullopt means "first active camera in the scene".
+  void updateCamera(const ObjectManager& objectManager, GpuAssetCache& assetCache,
+                    const std::optional<uuids::uuid>& cameraObject = std::nullopt);
+
   // True for the object under the cursor; the editor reads it to drive Ctrl-click selection.
   [[nodiscard]] bool isSelected(const uuids::uuid& uuid) const;
 

--- a/source/libs/scripting/CMakeLists.txt
+++ b/source/libs/scripting/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(${PROJECT_NAME}
   bindings/InputUtilsBindings.h
   bindings/WorldBindings.cpp
   bindings/WorldBindings.h
+  bindings/CameraBindings.cpp
+  bindings/CameraBindings.h
   bindings/InputState.cpp
   bindings/InputState.h
 )

--- a/source/libs/scripting/ScriptBridge/ScriptBase.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBase.cs
@@ -11,6 +11,10 @@ public abstract class ScriptBase
 
     protected Transform transform { get; private set; } = null!;
 
+    // This script's own camera (read-only), for moving relative to where the view faces. Reads a forward
+    // default (0,0,-1) if the object has no Camera.
+    protected Camera camera { get; private set; } = null!;
+
     // This script's own player's input, resolved through its object's PlayerController. Reads as "nothing
     // pressed" if the object has no PlayerController. Prefer this over the global InputUtils, which reads
     // every player's input aggregated together.
@@ -20,6 +24,7 @@ public abstract class ScriptBase
     {
         rigidBody = new RigidBody(EntityId);
         transform = new Transform(EntityId);
+        camera = new Camera(EntityId);
         input = new PlayerInput(EntityId);
     }
 

--- a/source/libs/scripting/ScriptBridge/ScriptBridge.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBridge.cs
@@ -297,6 +297,12 @@ public static class Bridge
     }
 
     [UnmanagedCallersOnly]
+    public static unsafe void registerCameraBindings(CameraBindings bindings)
+    {
+        NativeBindings.Camera = bindings;
+    }
+
+    [UnmanagedCallersOnly]
     public static void attachScript(IntPtr uuidPtr, IntPtr classNamePtr)
     {
         var uuid = Marshal.PtrToStringUTF8(uuidPtr)!;

--- a/source/libs/scripting/ScriptBridge/components/Camera.cs
+++ b/source/libs/scripting/ScriptBridge/components/Camera.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace ScriptBridge;
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct CameraBindings
+{
+    public delegate* unmanaged<IntPtr, float*, float*, float*, void> getDirection;
+    public delegate* unmanaged<IntPtr, bool> has;
+}
+
+// The object's camera (Phase 4), scoped to the object it was constructed from. Read-only for now: it
+// exposes the look direction so a script can move relative to where the camera faces. Reads the forward
+// default (0,0,-1) when the object has no Camera.
+public sealed unsafe class Camera
+{
+    private readonly IntPtr _uuid;
+
+    internal Camera(string uuid)
+    {
+        _uuid = Marshal.StringToCoTaskMemUTF8(uuid);
+    }
+
+    ~Camera()
+    {
+        Marshal.FreeCoTaskMem(_uuid);
+    }
+
+    public bool has() => NativeBindings.Camera.has(_uuid);
+
+    // The camera's local look direction (object space); (0,0,-1) is the object's forward.
+    public Vector3 getDirection()
+    {
+        float x = 0, y = 0, z = 0;
+        NativeBindings.Camera.getDirection(_uuid, &x, &y, &z);
+        return new Vector3(x, y, z);
+    }
+}

--- a/source/libs/scripting/ScriptBridge/components/NativeBindings.cs
+++ b/source/libs/scripting/ScriptBridge/components/NativeBindings.cs
@@ -9,4 +9,6 @@ internal static unsafe class NativeBindings
     internal static TransformBindings Transform;
 
     internal static WorldBindings World;
+
+    internal static CameraBindings Camera;
 }

--- a/source/libs/scripting/ScriptBridge/components/RigidBody.cs
+++ b/source/libs/scripting/ScriptBridge/components/RigidBody.cs
@@ -11,6 +11,8 @@ public unsafe struct RigidBodyBindings
     public delegate* unmanaged<IntPtr, float, float, float, void> setVelocity;
     public delegate* unmanaged<IntPtr, bool> isFalling;
     public delegate* unmanaged<IntPtr, bool> has;
+    // New fields go at the END to keep the layout matched with the native RigidBodyBindings struct.
+    public delegate* unmanaged<IntPtr, float, float, float, void> setAngularVelocity;
 }
 
 public unsafe class RigidBody
@@ -37,6 +39,12 @@ public unsafe class RigidBody
         NativeBindings.RigidBody.setVelocity(_uuid, x, y, z);
 
     public void setVelocity(Vector3 velocity) => setVelocity(velocity.X, velocity.Y, velocity.Z);
+
+    public void setAngularVelocity(float x, float y, float z) =>
+        NativeBindings.RigidBody.setAngularVelocity(_uuid, x, y, z);
+
+    public void setAngularVelocity(Vector3 angularVelocity) =>
+        setAngularVelocity(angularVelocity.X, angularVelocity.Y, angularVelocity.Z);
 
     public bool isFalling() => NativeBindings.RigidBody.isFalling(_uuid);
 }

--- a/source/libs/scripting/ScriptEngine.cpp
+++ b/source/libs/scripting/ScriptEngine.cpp
@@ -3,6 +3,7 @@
 #include "bindings/RigidBodyBindings.h"
 #include "bindings/InputUtilsBindings.h"
 #include "bindings/WorldBindings.h"
+#include "bindings/CameraBindings.h"
 #include <ManagedHost.h>
 #include <filesystem>
 #include <iostream>
@@ -95,6 +96,12 @@ void ScriptEngine::registerBindings(const std::string& assemblyPath,
   const auto registerInputUtils =
     reinterpret_cast<RegisterInputUtilsFn>(m_host->getDelegate(assemblyPath, typeName, "registerInputUtilsBindings"));
   registerInputUtils(InputUtilsBindingsProvider::getBindings());
+
+  // Read-only camera access (its look direction), so a script can move relative to where the camera faces.
+  using RegisterCameraFn = void(*)(CameraBindings);
+  const auto registerCamera =
+    reinterpret_cast<RegisterCameraFn>(m_host->getDelegate(assemblyPath, typeName, "registerCameraBindings"));
+  registerCamera(CameraBindingsProvider::getBindings());
 }
 
 void ScriptEngine::reloadScripts() const

--- a/source/libs/scripting/UserScripts/PlayerScript.cs
+++ b/source/libs/scripting/UserScripts/PlayerScript.cs
@@ -10,12 +10,28 @@ public class PlayerScript : ScriptBase
     [ExposeToEditor("Jump Force")]
     private float m_jumpForce = 15.0f;
 
+    [ExposeToEditor("Look Sensitivity")]
+    private float m_lookSensitivity = 0.15f;
+
+    [ExposeToEditor("Invert Look")]
+    private bool m_invertLook = false;
+
     private Vector3 m_appliedForce = new Vector3(0, 0, 0);
 
     private bool m_wasJumping = true;
 
+    // Accumulated mouse-look angles (degrees). The camera follows the object's rotation (RenderSystem
+    // rotates the Camera's direction by it), so rotating the Transform here is what turns the view.
+    private float m_yaw = 0.0f;
+    private float m_pitch = 0.0f;
+
     public override void start()
     {
+        // Seed from any editor-set body rotation so mouse-look starts from the placed facing.
+        Vector3 rotation = transform.getRotation();
+        m_pitch = rotation.X;
+        m_yaw = rotation.Y;
+
         Console.WriteLine("[PlayerScript] Player is ready!");
     }
 
@@ -34,11 +50,16 @@ public class PlayerScript : ScriptBase
         rigidBody.applyForce(m_appliedForce * dt, transform.getPosition());
 
         m_appliedForce *= 0;
+
+        // Mouse-look owns rotation, so cancel any physics spin (e.g. from a collision) before physics
+        // integrates it this tick — otherwise the view would fight/jitter against the look direction.
+        rigidBody.setAngularVelocity(0, 0, 0);
     }
 
     public override void variableUpdate()
     {
         handleInput();
+        handleLook();
     }
 
     public override void stop()
@@ -56,6 +77,32 @@ public class PlayerScript : ScriptBase
         transform.stop();
         transform.start();
         rigidBody.setVelocity(0, 0, 0);
+    }
+
+    private void handleLook()
+    {
+        if (!input.windowIsFocused())
+        {
+            return;
+        }
+
+        // Only look while the right mouse button is held (same convention as the free-fly camera), so plain
+        // cursor movement doesn't swing the view.
+        if (!input.mouseButton(MouseButton.Right))
+        {
+            return;
+        }
+
+        Vector2 delta = input.mouseDelta();
+
+        // Mouse right -> look right; mouse up -> look up (flip the vertical with Invert Look). Pitch is
+        // clamped shy of straight up/down so the view can't roll past vertical.
+        m_yaw -= delta.X * m_lookSensitivity;
+        float pitchStep = delta.Y * m_lookSensitivity;
+        m_pitch += m_invertLook ? pitchStep : -pitchStep;
+        m_pitch = Math.Clamp(m_pitch, -89.0f, 89.0f);
+
+        transform.setRotation(m_pitch, m_yaw, 0.0f);
     }
 
     private void handleInput()

--- a/source/libs/scripting/UserScripts/PlayerScript.cs
+++ b/source/libs/scripting/UserScripts/PlayerScript.cs
@@ -58,8 +58,9 @@ public class PlayerScript : ScriptBase
 
     public override void variableUpdate()
     {
-        handleInput();
+        // Look first so movement uses this tick's heading (movement is relative to the current yaw).
         handleLook();
+        handleInput();
     }
 
     public override void stop()
@@ -112,36 +113,59 @@ public class PlayerScript : ScriptBase
             return;
         }
 
-        float xForce = 0;
-        if (input.keyIsPressed(Key.LEFT))
-        {
-            xForce += m_speed;
-        }
-
-        if (input.keyIsPressed(Key.RIGHT))
-        {
-            xForce -= m_speed;
-        }
-
-        if (xForce != 0)
-        {
-            m_appliedForce.X = xForce;
-        }
-
-        float zForce = 0;
+        // Movement follows where the player faces: forward is the camera's forward projected onto the
+        // ground plane (yaw only, so looking up/down doesn't tilt movement). Assumes the camera's forward
+        // is the object's -Z, so the body's yaw is the movement heading.
+        float forwardInput = 0;
         if (input.keyIsPressed(Key.UP))
         {
-            zForce += m_speed;
+            forwardInput += 1.0f;
         }
 
         if (input.keyIsPressed(Key.DOWN))
         {
-            zForce -= m_speed;
+            forwardInput -= 1.0f;
         }
 
-        if (zForce != 0)
+        float strafeInput = 0;
+        if (input.keyIsPressed(Key.RIGHT))
         {
-            m_appliedForce.Z = zForce;
+            strafeInput += 1.0f;
+        }
+
+        if (input.keyIsPressed(Key.LEFT))
+        {
+            strafeInput -= 1.0f;
+        }
+
+        if (forwardInput != 0 || strafeInput != 0)
+        {
+            // Base heading is the camera's own facing (its direction field) on the ground plane, so
+            // "forward" follows wherever the camera actually points — not an assumed -Z.
+            Vector3 camDir = camera.getDirection();
+            Vector3 baseForward = new Vector3(camDir.X, 0.0f, camDir.Z);
+            baseForward = baseForward.LengthSquared() > 0.0001f
+                ? Vector3.Normalize(baseForward)
+                : new Vector3(0.0f, 0.0f, -1.0f); // camera looks straight up/down: fall back to forward
+
+            // Rotate the base heading by the body's current yaw (mouse-look), then derive right from it.
+            float yawRad = transform.getRotation().Y * (MathF.PI / 180.0f);
+            float cos = MathF.Cos(yawRad), sin = MathF.Sin(yawRad);
+            Vector3 forward = new Vector3(
+                baseForward.X * cos + baseForward.Z * sin,
+                0.0f,
+                -baseForward.X * sin + baseForward.Z * cos
+            );
+            Vector3 right = new Vector3(-forward.Z, 0.0f, forward.X);
+
+            Vector3 move = forward * forwardInput + right * strafeInput;
+            if (move.LengthSquared() > 0.0f)
+            {
+                move = Vector3.Normalize(move) * m_speed;
+            }
+
+            m_appliedForce.X = move.X;
+            m_appliedForce.Z = move.Z;
         }
 
         if (!m_wasJumping && !rigidBody.isFalling() && input.keyIsPressed(Key.X))

--- a/source/libs/scripting/bindings/CameraBindings.cpp
+++ b/source/libs/scripting/bindings/CameraBindings.cpp
@@ -1,0 +1,64 @@
+#include "CameraBindings.h"
+#include "BindingContext.h"
+#include <objects/Object.h>
+#include <objects/ObjectManager.h>
+#include <objects/components/Component.h>
+#include <objects/components/Camera.h>
+#include <memory>
+#include <string>
+
+namespace {
+  std::shared_ptr<Camera> find(const char* uuid)
+  {
+    const auto objectManager = BindingContext::getObjectManager();
+    if (!objectManager)
+    {
+      return nullptr;
+    }
+
+    const auto parsed = uuids::uuid::from_string(std::string(uuid));
+    if (!parsed.has_value())
+    {
+      return nullptr;
+    }
+
+    const auto object = objectManager->getObjectByUUID(parsed.value());
+    if (!object)
+    {
+      return nullptr;
+    }
+
+    return object->getComponent<Camera>(ComponentType::camera);
+  }
+}
+
+CameraBindings CameraBindingsProvider::getBindings()
+{
+  return CameraBindings {
+    .getDirection = &bindGetDirection,
+    .has = &bindHas
+  };
+}
+
+void CameraBindingsProvider::bindGetDirection(const char* uuid, float* x, float* y, float* z)
+{
+  const auto camera = find(uuid);
+  if (!camera)
+  {
+    // No camera: report a forward default so a caller that assumes it degrades safely.
+    *x = 0.0f;
+    *y = 0.0f;
+    *z = -1.0f;
+    return;
+  }
+
+  const auto direction = camera->getDirection();
+  *x = direction.x;
+  *y = direction.y;
+  *z = direction.z;
+}
+
+bool CameraBindingsProvider::bindHas(const char* uuid)
+{
+  return find(uuid) != nullptr;
+}

--- a/source/libs/scripting/bindings/CameraBindings.h
+++ b/source/libs/scripting/bindings/CameraBindings.h
@@ -1,0 +1,27 @@
+#ifndef CAMERABINDINGS_H
+#define CAMERABINDINGS_H
+
+struct CameraBindings
+{
+  void(*getDirection)(const char* uuid, float* x, float* y, float* z);
+  bool(*has)(const char* uuid);
+};
+
+class CameraBindingsProvider {
+public:
+  [[nodiscard]] static CameraBindings getBindings();
+
+private:
+  // find() resolves a uuid against the server's ObjectManager via BindingContext (set by ScriptSystem).
+
+  // Reads the object's Camera direction (its local look vector). Writes the forward default (0,0,-1) when
+  // the object has no Camera, so a script that moves relative to the camera degrades safely.
+  static void bindGetDirection(const char* uuid, float* x, float* y, float* z);
+
+  // Whether the object identified by uuid currently has a Camera.
+  static bool bindHas(const char* uuid);
+};
+
+
+
+#endif //CAMERABINDINGS_H

--- a/source/libs/scripting/bindings/RigidBodyBindings.cpp
+++ b/source/libs/scripting/bindings/RigidBodyBindings.cpp
@@ -38,7 +38,8 @@ RigidBodyBindings RigidBodyBindingsProvider::getBindings()
     .applyForce = &bindApplyForce,
     .setVelocity = &bindSetVelocity,
     .isFalling = &bindIsFalling,
-    .has = &bindHas
+    .has = &bindHas,
+    .setAngularVelocity = &bindSetAngularVelocity
   };
 }
 
@@ -64,6 +65,17 @@ void RigidBodyBindingsProvider::bindSetVelocity(const char* uuid, float x, float
   }
 
   rigidBody->setVelocity({ x, y, z });
+}
+
+void RigidBodyBindingsProvider::bindSetAngularVelocity(const char* uuid, float x, float y, float z)
+{
+  const auto rigidBody = find(uuid);
+  if (!rigidBody)
+  {
+    return;
+  }
+
+  rigidBody->setAngularVelocity({ x, y, z });
 }
 
 bool RigidBodyBindingsProvider::bindIsFalling(const char* uuid)

--- a/source/libs/scripting/bindings/RigidBodyBindings.h
+++ b/source/libs/scripting/bindings/RigidBodyBindings.h
@@ -7,6 +7,8 @@ struct RigidBodyBindings
   void(*setVelocity)(const char* uuid, float x, float y, float z);
   bool(*isFalling)(const char* uuid);
   bool(*has)(const char* uuid);
+  // New fields go at the END to keep the layout matched with the C# RigidBodyBindings struct.
+  void(*setAngularVelocity)(const char* uuid, float x, float y, float z);
 };
 
 class RigidBodyBindingsProvider {
@@ -18,6 +20,10 @@ private:
   // data (PhysicsSystem drains it each tick) so scripting stays independent of ECS3DSim.
   static void bindApplyForce(const char* uuid, float x, float y, float z, float px, float py, float pz);
   static void bindSetVelocity(const char* uuid, float x, float y, float z);
+
+  // Overwrite the angular velocity (rad/s). A player script zeroes it to keep mouse-look authoritative
+  // (physics integrates rotation from angular velocity, which a collision-induced spin would otherwise fight).
+  static void bindSetAngularVelocity(const char* uuid, float x, float y, float z);
 
   static bool bindIsFalling(const char* uuid);
 


### PR DESCRIPTION
This pull request implements full support for player-driven cameras in both the client and editor, enabling each client to view the scene through the camera associated with their own player object. It introduces a handshake mechanism to associate clients with their player slot, updates the rendering logic to select the correct camera, and enhances the editor to display and select cameras by object and player. Additional improvements clarify conventions and update documentation for these new features.

**Player Camera System Integration:**

* Added a per-client handshake using a random nonce to assign player slots, allowing each client to identify and render through its own player camera (`ClientApp.cpp`/`.h`). [[1]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaL44-R54) [[2]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaR233-R236) [[3]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaR288-R331) [[4]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aR73-R79)
* Implemented `resolvePlayerCamera()` to select the correct camera for rendering based on the player's slot; falls back to default/free-fly if unavailable. [[1]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaR200-R203) [[2]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaR288-R331) [[3]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aR99-R105)

**Editor Camera Selection and Input Handling:**

* Enhanced the editor's camera selection UI to label cameras by owning object and player slot, and to indicate inactive cameras. [[1]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R48-R69) [[2]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L621-R656) [[3]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R717-R718)
* Updated input handling so mouse control is only forwarded to the game when the editor is looking through a scene camera and the viewport is focused, preventing conflicts with editor controls.

**Component and Editor Registration:**

* Registered new `Camera` and `PlayerController` components and their editors, ensuring they are available for editing and serialization in the editor. [[1]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R21-R30) [[2]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R385)

**Documentation Updates:**

* Expanded and clarified documentation in `AGENTS.md` to describe the player camera system, conventions for script bindings, and updated build verification policies. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L31-R36) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L117-R121) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L134-R171) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L179-R218)

These changes collectively enable per-player camera views in multiplayer sessions, improve editor usability, and ensure the documentation reflects the updated architecture.