### PR TITLE
Implement asset renaming and deletion in Inspector with overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 | `source/libs/data/` | `ECS3DData` — the foundation. Component **data** (Transform, RigidBody, ModelRenderer, LightRenderer, Colliders, Script, PlayerController, Camera), `Object`/`ObjectManager`, scenes, `AssetRegistry` (incl. prefab bodies), `ComponentRegistry`, `ProjectSerializer` (JSON file save/load) / `ProjectPacker` (binary wire snapshot), `Replication`. **No Vulkan, no ImGui.** |
 | `source/libs/sim/` | `ECS3DSim` — `PhysicsSystem` (integration, forces, response) and `CollisionSystem` (sweep-and-prune + GJK/EPA under `collisions/`). Operates on `ECS3DData` via accessors. OpenMP if available. |
 | `source/libs/render/` | `ECS3DRender` — `RenderSystem` (draws models/lights, pick feedback, selection highlight, collider gizmos, and drives the `vke::Camera`/`Renderer3D` view from the scene's active `Camera` component), `GpuAssetCache` (UUID → `vke` GPU objects), `InputCapture`. Depends on `ECS3DData` + `VulkanEngine`. |
-| `source/libs/editor/` | `ECS3DEditorLib` — ImGui editing UI: `ComponentEditor` (per-type handlers), `ObjectGUIManager` (object tree), `InspectorPanel` (the "Inspector" window — per-selection-kind dispatch) delegating the object kind to `ObjectInspector` and the asset kind to `AssetInspector` (read-only per-`AssetType` views), `EditorSelection` (shared kind-tagged selection slot, `Selection.h`), `AssetBrowserPanel`, `AssetDisplay` (shared asset label/name/icon/color rules, header-only), `SaveUI`, `GuiComponents`. Depends on `ECS3DData` + `ECS3DRender` + `nfd`. |
+| `source/libs/editor/` | `ECS3DEditorLib` — ImGui editing UI: `ComponentEditor` (per-type handlers), `ObjectGUIManager` (object tree), `InspectorPanel` (the "Inspector" window — per-selection-kind dispatch) delegating the object kind to `ObjectInspector` and the asset kind to `AssetInspector` (per-`AssetType` views — read-only detail plus a display-name rename field and a delete button with a reference-count warning for the flat file assets), `EditorSelection` (shared kind-tagged selection slot, `Selection.h`), `AssetBrowserPanel`, `AssetDisplay` (shared asset label/name/icon/color rules, header-only), `SaveUI`, `GuiComponents`. Depends on `ECS3DData` + `ECS3DRender` + `nfd`. |
 | `source/libs/net/` | `ECS3DNet` — `NetServer`/`NetClient`/`MessageQueue`/`ServerProcess` (C++), plus the `Transport/` C# assembly (`ECS3DNetTransport`, TCP + WebSocket backends). |
 | `source/libs/scripting/` | `ECS3DScripting` — `ScriptSystem`/`ScriptEngine` + native `bindings/` (Transform, RigidBody, InputUtils, World, Camera; `InputState`, `BindingContext`), plus the `ScriptBridge/` C# assembly and example `UserScripts/`. |
 | `source/libs/clrHost/` | `ECS3DClrHost` — `ManagedHost` boots CoreCLR and hands out managed statics as native fn ptrs. Owns the CMake helpers (`cmake/ECS3DManaged.cmake`, `FindDotnet.cmake`, `loadCS.cmake`). |
@@ -88,8 +88,20 @@ the JSON path for file save/load) — sent on join and rebroadcast after any str
 rebuilds from it, atomically (a malformed packet leaves the current project intact). Per-tick motion
 goes as a compact binary **stateDelta** (uuid + local transform per object; `data/Replication.{h,cpp}`).
 Edits flow the other way as typed commands (`editComponent`, `sceneEdit`, `sceneControl`, `loadProject`,
-`addAsset`) that only a connection authorized as `Role::editor` on an `--edit` server may send. (`sceneEdit`
-carries the prefab-instantiation op too — see Prefabs below.)
+`addAsset`, `renameAsset`, `removeAsset`) that only a connection authorized as `Role::editor` on an
+`--edit` server may send. (`sceneEdit` carries the prefab-instantiation op too — see Prefabs below.) The
+asset-mutation trio (`addAsset`/`renameAsset`/`removeAsset`, built/packed in `data/Replication.{h,cpp}`,
+applied by `AssetRegistry`) all follow the **local-apply-then-send** shape: the editor mutates its own
+registry for instant feedback, then sends the op and the server re-snapshots. **Rename is display-only** —
+a `renameAsset` sets an optional `AssetRecord::displayName` override (threaded through
+`serialize`/`loadFromJSON`/`pack`/`unpack` like every other field); the file on disk and `path` (the
+registry key, and the name-key for prefabs/scenes) never change. **Delete always succeeds and references
+dangle** — `removeAsset` drops the record; `GpuAssetCache`/`AssetRegistry` lookups already null-tolerate a
+missing uuid so referencing slots just show "None". The editor warns before deleting by scanning its
+replicated scenes + prefab bodies for the uuid ("referenced by N objects"); no server-side refusal or
+cascade exists (see `ROADMAP.md` B1). Rename/delete are offered only for the flat file assets
+(Model/Texture/Script/Prefab) that `AssetRegistry` owns — a Scene record is regenerated from the
+`SceneManager` on every snapshot, so an override on it wouldn't survive.
 Runtime structural changes from a *script* (spawn/destroy) take a third path: lightweight
 `objectSpawned` (one packed `Object`) / `objectDestroyed` (a uuid) messages the client splices into/out of
 its scene incrementally — kept off the full-snapshot path so frequent spawning stays cheap. Build/apply

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -67,6 +67,54 @@ namespace {
 
     return label;
   }
+
+  // Whether any of an object's components serialize the asset uuid (models/textures store it as a string
+  // field — see ModelRenderer::serialize). Searching the serialized form keeps this generic: no layer here
+  // names a concrete component type. Scripts reference assets by class name and prefab instances are
+  // detached copies, so only model/texture uuids ever match — exactly the references that would dangle.
+  bool objectReferencesAsset(const std::shared_ptr<Object>& object, const std::string& uuidString)
+  {
+    for (const auto& [type, component] : object->getComponents())
+    {
+      if (component->serialize().dump().find(uuidString) != std::string::npos)
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // Count the object nodes within a serialized prefab body (one Object tree) that reference the uuid.
+  int countReferencesInPrefabNode(const nlohmann::json& node, const std::string& uuidString)
+  {
+    int count = 0;
+
+    if (const auto components = node.find("components"); components != node.end() && components->is_array())
+    {
+      for (const auto& component : *components)
+      {
+        if (component.dump().find(uuidString) != std::string::npos)
+        {
+          ++count;
+          break;
+        }
+      }
+    }
+
+    if (const auto children = node.find("children"); children != node.end() && children->is_array())
+    {
+      for (const auto& child : *children)
+      {
+        if (child.is_object())
+        {
+          count += countReferencesInPrefabNode(child, uuidString);
+        }
+      }
+    }
+
+    return count;
+  }
 }
 
 EditorApp::EditorApp(LaunchOptions options)
@@ -109,6 +157,54 @@ EditorApp::EditorApp(LaunchOptions options)
     replication::applyRenameAsset(*m_assetRegistry, op);
 
     m_netClient->send(replication::packRenameAsset(op));
+  };
+
+  // Deleting an asset: same local-apply-then-send shape. Deletion always succeeds; any references dangle
+  // (lookups null-tolerate a missing uuid), so nothing else needs to change here.
+  const auto removeAsset = [this](const uuids::uuid& assetUUID) {
+    const auto op = replication::buildRemoveAsset(assetUUID);
+    replication::applyRemoveAsset(*m_assetRegistry, op);
+
+    m_netClient->send(replication::packRemoveAsset(op));
+  };
+
+  // How many objects reference an asset by uuid, for the delete-confirmation modal's warning. Scans the
+  // replicated scenes' objects and every prefab body — the two places an object tree lives editor-side.
+  const auto countAssetReferences = [this](const uuids::uuid& assetUUID) {
+    const auto uuidString = uuids::to_string(assetUUID);
+    int count = 0;
+
+    for (const auto& [sceneUUID, scene] : m_sceneManager->getScenes())
+    {
+      const auto objectManager = scene->getObjectManager();
+      if (!objectManager)
+      {
+        continue;
+      }
+
+      for (const auto& object : objectManager->getAllObjects())
+      {
+        if (objectReferencesAsset(object, uuidString))
+        {
+          ++count;
+        }
+      }
+    }
+
+    for (const auto& [recordUUID, record] : m_assetRegistry->getAssets())
+    {
+      if (record.type != AssetType::Prefab)
+      {
+        continue;
+      }
+
+      if (auto body = nlohmann::json::parse(record.body, nullptr, false); !body.is_discarded() && body.is_object())
+      {
+        count += countReferencesInPrefabNode(body, uuidString);
+      }
+    }
+
+    return count;
   };
 
   // A component widget changed: send the component's new state to the authoritative server as an edit
@@ -162,6 +258,8 @@ EditorApp::EditorApp(LaunchOptions options)
   m_inspectorPanel->setSceneEditCallback(sceneEdit);
   m_inspectorPanel->setLoadSceneCallback(loadScene);
   m_inspectorPanel->setRenameAssetCallback(renameAsset);
+  m_inspectorPanel->setRemoveAssetCallback(removeAsset);
+  m_inspectorPanel->setAssetReferenceCountCallback(countAssetReferences);
 
   m_assetBrowser = std::make_shared<AssetBrowserPanel>(m_assetRegistry.get(), m_assetCache);
   m_assetBrowser->setSelection(m_selection);

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -102,6 +102,15 @@ EditorApp::EditorApp(LaunchOptions options)
     m_netClient->send(replication::packAddAsset(asset));
   };
 
+  // Renaming an asset (display-name override only): apply locally for instant feedback, then on the
+  // authoritative server (which re-snapshots). Same local-apply-then-send shape as addAsset.
+  const auto renameAsset = [this](const uuids::uuid& assetUUID, const std::string& displayName) {
+    const auto op = replication::buildRenameAsset(assetUUID, displayName);
+    replication::applyRenameAsset(*m_assetRegistry, op);
+
+    m_netClient->send(replication::packRenameAsset(op));
+  };
+
   // A component widget changed: send the component's new state to the authoritative server as an edit
   // command. Only the Inspector fires this (component value edits).
   const auto editComponent = [this](const uuids::uuid& objectUUID, const std::shared_ptr<Component>& component) {
@@ -152,6 +161,7 @@ EditorApp::EditorApp(LaunchOptions options)
   m_inspectorPanel->setEditCallback(editComponent);
   m_inspectorPanel->setSceneEditCallback(sceneEdit);
   m_inspectorPanel->setLoadSceneCallback(loadScene);
+  m_inspectorPanel->setRenameAssetCallback(renameAsset);
 
   m_assetBrowser = std::make_shared<AssetBrowserPanel>(m_assetRegistry.get(), m_assetCache);
   m_assetBrowser->setSelection(m_selection);

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -246,6 +246,8 @@ namespace {
       case net::MessageType::sceneControl:
       case net::MessageType::loadProject:
       case net::MessageType::addAsset:
+      case net::MessageType::renameAsset:
+      case net::MessageType::removeAsset:
         return true;
       default:
         return false;
@@ -282,6 +284,14 @@ void ServerApp::handleClientMessage(const net::Message& message, const int32_t s
 
     case net::MessageType::addAsset:
       handleAddAsset(message);
+      break;
+
+    case net::MessageType::renameAsset:
+      handleRenameAsset(message);
+      break;
+
+    case net::MessageType::removeAsset:
+      handleRemoveAsset(message);
       break;
 
     case net::MessageType::inputState:
@@ -486,6 +496,47 @@ void ServerApp::handleAddAsset(const net::Message& message) const
   replication::applyAddAsset(*m_assetRegistry, *m_sceneManager, m_componentRegistry, asset);
 
   logMessage("Info", "Registered asset (" + asset.value("assetType", std::string{}) + ").");
+
+  broadcastSnapshot();
+}
+
+void ServerApp::handleRenameAsset(const net::Message& message) const
+{
+  // An editor renamed an asset (display-name override only): apply it authoritatively and re-snapshot.
+  nlohmann::json op;
+  try
+  {
+    op = replication::unpackRenameAsset(message);
+  }
+  catch (const std::exception&)
+  {
+    return;
+  }
+
+  replication::applyRenameAsset(*m_assetRegistry, op);
+
+  logMessage("Info", "Renamed asset.");
+
+  broadcastSnapshot();
+}
+
+void ServerApp::handleRemoveAsset(const net::Message& message) const
+{
+  // An editor deleted an asset: drop the record and re-snapshot. References dangle by design (lookups
+  // null-tolerate a missing uuid) — see ROADMAP B1.
+  nlohmann::json op;
+  try
+  {
+    op = replication::unpackRemoveAsset(message);
+  }
+  catch (const std::exception&)
+  {
+    return;
+  }
+
+  replication::applyRemoveAsset(*m_assetRegistry, op);
+
+  logMessage("Info", "Removed asset.");
 
   broadcastSnapshot();
 }

--- a/source/apps/server/ServerApp.h
+++ b/source/apps/server/ServerApp.h
@@ -103,6 +103,10 @@ private:
 
   void handleAddAsset(const net::Message& message) const;
 
+  void handleRenameAsset(const net::Message& message) const;
+
+  void handleRemoveAsset(const net::Message& message) const;
+
   void handleInputState(const net::Message& message, int32_t senderId);
 
   void handleSceneControl(const net::Message& message) const;

--- a/source/libs/data/Replication.cpp
+++ b/source/libs/data/Replication.cpp
@@ -561,4 +561,81 @@ nlohmann::json unpackAddAsset(const net::Message& message)
   return asset;
 }
 
+nlohmann::json buildRenameAsset(const uuids::uuid& assetUUID, const std::string& displayName)
+{
+  return {
+    { "uuid", uuids::to_string(assetUUID) },
+    { "displayName", displayName }
+  };
+}
+
+nlohmann::json buildRemoveAsset(const uuids::uuid& assetUUID)
+{
+  return {
+    { "uuid", uuids::to_string(assetUUID) }
+  };
+}
+
+void applyRenameAsset(AssetRegistry& assetRegistry, const nlohmann::json& op)
+{
+  const auto parsed = uuids::uuid::from_string(op.value("uuid", std::string{}));
+  if (!parsed.has_value())
+  {
+    return;
+  }
+
+  assetRegistry.renameAsset(parsed.value(), op.value("displayName", std::string{}));
+}
+
+void applyRemoveAsset(AssetRegistry& assetRegistry, const nlohmann::json& op)
+{
+  const auto parsed = uuids::uuid::from_string(op.value("uuid", std::string{}));
+  if (!parsed.has_value())
+  {
+    return;
+  }
+
+  assetRegistry.removeAsset(parsed.value());
+}
+
+net::Message packRenameAsset(const nlohmann::json& op)
+{
+  net::Message message(net::MessageType::renameAsset);
+
+  message.writeString(op.value("uuid", std::string{}));
+  message.writeString(op.value("displayName", std::string{}));
+
+  return message;
+}
+
+nlohmann::json unpackRenameAsset(const net::Message& message)
+{
+  net::MessageReader reader(message);
+
+  nlohmann::json op;
+  op["uuid"] = reader.readString();
+  op["displayName"] = reader.readString();
+
+  return op;
+}
+
+net::Message packRemoveAsset(const nlohmann::json& op)
+{
+  net::Message message(net::MessageType::removeAsset);
+
+  message.writeString(op.value("uuid", std::string{}));
+
+  return message;
+}
+
+nlohmann::json unpackRemoveAsset(const net::Message& message)
+{
+  net::MessageReader reader(message);
+
+  nlohmann::json op;
+  op["uuid"] = reader.readString();
+
+  return op;
+}
+
 }

--- a/source/libs/data/Replication.h
+++ b/source/libs/data/Replication.h
@@ -98,6 +98,26 @@ void applyAddAsset(AssetRegistry& assetRegistry,
 
 [[nodiscard]] nlohmann::json unpackAddAsset(const net::Message& message);
 
+// Asset mutation ({ uuid, [displayName] }). Rename is a display-name override only; remove drops the
+// record and lets references dangle (see ROADMAP B1). Both mirror addAsset's local-apply-then-send shape:
+// the editor applies locally for instant feedback and sends the op; the server applies it authoritatively
+// and re-snapshots. The build* helpers assemble the blob; pack*/unpack* carry it on the wire.
+[[nodiscard]] nlohmann::json buildRenameAsset(const uuids::uuid& assetUUID, const std::string& displayName);
+
+[[nodiscard]] nlohmann::json buildRemoveAsset(const uuids::uuid& assetUUID);
+
+void applyRenameAsset(AssetRegistry& assetRegistry, const nlohmann::json& op);
+
+void applyRemoveAsset(AssetRegistry& assetRegistry, const nlohmann::json& op);
+
+[[nodiscard]] net::Message packRenameAsset(const nlohmann::json& op);
+
+[[nodiscard]] nlohmann::json unpackRenameAsset(const net::Message& message);
+
+[[nodiscard]] net::Message packRemoveAsset(const nlohmann::json& op);
+
+[[nodiscard]] nlohmann::json unpackRemoveAsset(const net::Message& message);
+
 }
 
 

--- a/source/libs/data/assets/AssetRegistry.cpp
+++ b/source/libs/data/assets/AssetRegistry.cpp
@@ -32,6 +32,41 @@ void AssetRegistry::registerAsset(const AssetRecord& record)
   ++m_version;
 }
 
+void AssetRegistry::renameAsset(const uuids::uuid& uuid, const std::string& displayName)
+{
+  const auto it = m_assets.find(uuid);
+  if (it == m_assets.end())
+  {
+    return;
+  }
+
+  // Display-only: `path` (the key, and the name-key for prefabs/scenes) stays put, so nothing that
+  // resolves the asset by path or uuid is disturbed — only the shown name changes.
+  it->second.displayName = displayName;
+  ++m_version;
+}
+
+void AssetRegistry::removeAsset(const uuids::uuid& uuid)
+{
+  const auto it = m_assets.find(uuid);
+  if (it == m_assets.end())
+  {
+    return;
+  }
+
+  // Free the path key too so its name (a prefab/scene display name, or a file path) can be registered
+  // again later. Guard on the mapping actually pointing back at this uuid — a first-wins collision earlier
+  // may have left the key owned by a different record.
+  if (const auto pathIt = m_loadedPaths.find(it->second.path);
+      pathIt != m_loadedPaths.end() && pathIt->second == uuid)
+  {
+    m_loadedPaths.erase(pathIt);
+  }
+
+  m_assets.erase(it);
+  ++m_version;
+}
+
 void AssetRegistry::clear()
 {
   m_assets.clear();

--- a/source/libs/data/assets/AssetRegistry.cpp
+++ b/source/libs/data/assets/AssetRegistry.cpp
@@ -93,6 +93,16 @@ nlohmann::json AssetRegistry::serialize() const
     { "prefabs", nlohmann::json::array() }
   };
 
+  // A rename sets a display-name override on the record; write it (append only, omitted when empty) so a
+  // renamed asset survives a save/load. The file on disk and `path` never change — only this override.
+  const auto withDisplayName = [](nlohmann::json entry, const AssetRecord& record) {
+    if (!record.displayName.empty())
+    {
+      entry["displayName"] = record.displayName;
+    }
+    return entry;
+  };
+
   for (const auto& [uuid, record] : m_assets)
   {
     const auto uuidString = uuids::to_string(uuid);
@@ -100,13 +110,13 @@ nlohmann::json AssetRegistry::serialize() const
     switch (record.type)
     {
       case AssetType::Model:
-        data["models"].push_back({ { "name", record.path }, { "filePath", record.path }, { "uuid", uuidString } });
+        data["models"].push_back(withDisplayName({ { "name", record.path }, { "filePath", record.path }, { "uuid", uuidString } }, record));
         break;
       case AssetType::Texture:
-        data["textures"].push_back({ { "name", record.path }, { "filePath", record.path }, { "uuid", uuidString } });
+        data["textures"].push_back(withDisplayName({ { "name", record.path }, { "filePath", record.path }, { "uuid", uuidString } }, record));
         break;
       case AssetType::Script:
-        data["scripts"].push_back({ { "className", record.className }, { "filePath", record.path }, { "uuid", uuidString } });
+        data["scripts"].push_back(withDisplayName({ { "className", record.className }, { "filePath", record.path }, { "uuid", uuidString } }, record));
         break;
       case AssetType::Prefab:
       {
@@ -115,11 +125,11 @@ nlohmann::json AssetRegistry::serialize() const
         // dump(), so a corrupt body is written as null and dropped on the next load.
         auto body = nlohmann::json::parse(record.body, nullptr, false);
 
-        data["prefabs"].push_back({
+        data["prefabs"].push_back(withDisplayName({
           { "name", record.path },
           { "uuid", uuidString },
           { "body", body.is_discarded() ? nlohmann::json(nullptr) : std::move(body) }
-        });
+        }, record));
         break;
       }
       default:
@@ -139,7 +149,8 @@ void AssetRegistry::loadFromJSON(const nlohmann::json& assetsData)
       registerAsset({
         .uuid = uuids::uuid::from_string(std::string(assetData.at("uuid"))).value(),
         .type = AssetType::Model,
-        .path = assetData.at("filePath")
+        .path = assetData.at("filePath"),
+        .displayName = assetData.value("displayName", std::string{})
       });
     }
   }
@@ -151,7 +162,8 @@ void AssetRegistry::loadFromJSON(const nlohmann::json& assetsData)
       registerAsset({
         .uuid = uuids::uuid::from_string(std::string(assetData.at("uuid"))).value(),
         .type = AssetType::Texture,
-        .path = assetData.at("filePath")
+        .path = assetData.at("filePath"),
+        .displayName = assetData.value("displayName", std::string{})
       });
     }
   }
@@ -164,7 +176,8 @@ void AssetRegistry::loadFromJSON(const nlohmann::json& assetsData)
         .uuid = uuids::uuid::from_string(std::string(assetData.at("uuid"))).value(),
         .type = AssetType::Script,
         .path = assetData.at("filePath"),
-        .className = assetData.at("className")
+        .className = assetData.at("className"),
+        .displayName = assetData.value("displayName", std::string{})
       });
     }
   }
@@ -184,7 +197,8 @@ void AssetRegistry::loadFromJSON(const nlohmann::json& assetsData)
         .uuid = uuids::uuid::from_string(std::string(assetData.at("uuid"))).value(),
         .type = AssetType::Prefab,
         .path = assetData.at("name"),                 // prefabs key off their display name
-        .body = assetData.at("body").dump()
+        .body = assetData.at("body").dump(),
+        .displayName = assetData.value("displayName", std::string{})
       });
     }
   }
@@ -211,8 +225,9 @@ void AssetRegistry::pack(net::Message& message) const
     message.write(record->type);
     message.writeString(uuids::to_string(record->uuid));
     message.writeString(record->path);
-    message.writeString(record->className); // empty for non-scripts
-    message.writeString(record->body);      // empty for non-prefabs
+    message.writeString(record->className);   // empty for non-scripts
+    message.writeString(record->body);        // empty for non-prefabs
+    message.writeString(record->displayName); // empty unless renamed (append-only wire field)
   }
 }
 
@@ -226,7 +241,9 @@ void AssetRegistry::unpack(net::MessageReader& messageReader)
     const auto path = messageReader.readString();
     const auto className = messageReader.readString();
     const auto body = messageReader.readString();
+    const auto displayName = messageReader.readString();
 
-    registerAsset({ .uuid = uuid, .type = type, .path = path, .className = className, .body = body });
+    registerAsset({ .uuid = uuid, .type = type, .path = path, .className = className, .body = body,
+                    .displayName = displayName });
   }
 }

--- a/source/libs/data/assets/AssetRegistry.h
+++ b/source/libs/data/assets/AssetRegistry.h
@@ -46,6 +46,16 @@ public:
   // whose body is updated in place (keeping its uuid) — see registerAsset.
   void registerAsset(const AssetRecord& record);
 
+  // Set a record's display-name override (a display-only rename; the file on disk and `path` — the
+  // registry key — are untouched, so name-keyed prefabs/scenes keep their identity). No-op for an unknown
+  // uuid. Bumps the version so cached views refresh. See ROADMAP B1.
+  void renameAsset(const uuids::uuid& uuid, const std::string& displayName);
+
+  // Drop a record by uuid, also clearing its `path` key (so a name-keyed prefab name frees up for reuse).
+  // No-op for an unknown uuid. References to it dangle by design — lookups already null-tolerate a missing
+  // uuid (see ROADMAP B1). Bumps the version.
+  void removeAsset(const uuids::uuid& uuid);
+
   // Drop all records (used when (re)loading a project / applying a fresh snapshot).
   void clear();
 

--- a/source/libs/data/assets/AssetRegistry.h
+++ b/source/libs/data/assets/AssetRegistry.h
@@ -24,9 +24,12 @@ enum class AssetType {
 struct AssetRecord {
   uuids::uuid uuid;
   AssetType type = AssetType::Unknown;
-  std::string path;      // scenes and prefabs store their display name here instead
-  std::string className; // scripts only
-  std::string body;      // prefabs only: a serialized Object blob (Object::serialize().dump())
+  std::string path;        // scenes and prefabs store their display name here instead
+  std::string className;   // scripts only
+  std::string body;        // prefabs only: a serialized Object blob (Object::serialize().dump())
+  std::string displayName; // optional rename override: when non-empty it replaces the derived display
+                           // name (see assetDisplay::name). The file on disk and `path` (the registry
+                           // key) never change — a rename is display-only (see ROADMAP B1).
 };
 
 // uuid<->path registry + serialize. Carries asset metadata only (no GPU resources, no GUI).

--- a/source/libs/editor/AssetDisplay.h
+++ b/source/libs/editor/AssetDisplay.h
@@ -27,9 +27,15 @@ namespace assetDisplay {
     }
   }
 
-  // The display name shown in the browser tile + inspector header.
+  // The display name shown in the browser tile + inspector header. A rename sets an override that wins
+  // over the type-derived name; the file on disk and `path` (the registry key) are untouched.
   inline std::string name(const AssetRecord& record)
   {
+    if (!record.displayName.empty())
+    {
+      return record.displayName;
+    }
+
     switch (record.type)
     {
       // Scenes and prefabs store their display name in `path` (neither is a file on disk).

--- a/source/libs/editor/AssetInspector.cpp
+++ b/source/libs/editor/AssetInspector.cpp
@@ -27,6 +27,22 @@ void AssetInspector::setLoadSceneCallback(LoadSceneCallback callback)
   m_onLoadScene = std::move(callback);
 }
 
+void AssetInspector::setRenameCallback(RenameCallback callback)
+{
+  m_onRename = std::move(callback);
+}
+
+namespace {
+  // A display-name rename is a display-only override the AssetRegistry packs (see AssetRegistry::pack): it
+  // survives a snapshot only for the flat file assets. A Scene record is regenerated from the SceneManager
+  // on every snapshot (and never packed), so its override wouldn't stick — keep the scene name read-only.
+  bool isRenamable(const AssetType type)
+  {
+    return type == AssetType::Model || type == AssetType::Texture
+        || type == AssetType::Script || type == AssetType::Prefab;
+  }
+}
+
 void AssetInspector::setEditable(const bool editable)
 {
   m_editable = editable;
@@ -62,10 +78,37 @@ void AssetInspector::display(const AssetRecord& record, const std::optional<uuid
   }
 }
 
-void AssetInspector::displayHeader(const AssetRecord& record) const
+void AssetInspector::displayHeader(const AssetRecord& record)
 {
-  // Display name (primary text), then metadata rows shared by every asset type.
-  ImGui::TextColored(theme::t1, "%s", assetDisplay::name(record).c_str());
+  // Re-seed the name buffer with the effective display name when the selection changes (only then, so an
+  // external rename can't overwrite an in-progress edit — same discipline as ObjectInspector).
+  if (m_nameEditUUID != record.uuid)
+  {
+    m_nameEditUUID = record.uuid;
+    const auto name = assetDisplay::name(record);
+    const auto len = std::min(name.size(), m_nameEditBuffer.size() - 1);
+    name.copy(m_nameEditBuffer.data(), len);
+    m_nameEditBuffer[len] = '\0';
+  }
+
+  // Display name: an editable rename field for the flat file assets (gated on editable), read-only text
+  // for scenes (their override wouldn't survive a snapshot — see isRenamable).
+  if (isRenamable(record.type))
+  {
+    ImGui::BeginDisabled(!m_editable);
+    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+    if (ImGui::InputText(("##assetName" + uuids::to_string(record.uuid)).c_str(),
+                         m_nameEditBuffer.data(), m_nameEditBuffer.size()) && m_onRename)
+    {
+      // Immediate send on each edit (like object rename), so switching selection can't lose the change.
+      m_onRename(record.uuid, m_nameEditBuffer.data());
+    }
+    ImGui::EndDisabled();
+  }
+  else
+  {
+    ImGui::TextColored(theme::t1, "%s", assetDisplay::name(record).c_str());
+  }
 
   ImGui::Spacing();
 

--- a/source/libs/editor/AssetInspector.cpp
+++ b/source/libs/editor/AssetInspector.cpp
@@ -32,6 +32,16 @@ void AssetInspector::setRenameCallback(RenameCallback callback)
   m_onRename = std::move(callback);
 }
 
+void AssetInspector::setRemoveCallback(RemoveCallback callback)
+{
+  m_onRemove = std::move(callback);
+}
+
+void AssetInspector::setReferenceCountCallback(ReferenceCountCallback callback)
+{
+  m_onReferenceCount = std::move(callback);
+}
+
 namespace {
   // A display-name rename is a display-only override the AssetRegistry packs (see AssetRegistry::pack): it
   // survives a snapshot only for the flat file assets. A Scene record is regenerated from the SceneManager
@@ -76,6 +86,11 @@ void AssetInspector::display(const AssetRecord& record, const std::optional<uuid
     case AssetType::Prefab:  displayPrefabBody();         break;
     default: break;
   }
+
+  // Delete lives at the foot of the panel, for the flat file assets only (a Scene's removal isn't a
+  // registry op — see isRenamable / ROADMAP B1). The modal is drawn every frame the button is armed.
+  displayDeleteButton(record);
+  displayDeleteConfirmationModal(record);
 }
 
 void AssetInspector::displayHeader(const AssetRecord& record)
@@ -451,4 +466,106 @@ void AssetInspector::displayPrefabNode(const PrefabNode& node, const bool root) 
   }
 
   ImGui::PopID();
+}
+
+void AssetInspector::displayDeleteButton(const AssetRecord& record)
+{
+  // Only the flat file assets can be deleted from here (a Scene lives in the SceneManager, not a registry
+  // record we can drop — see isRenamable).
+  if (!isRenamable(record.type))
+  {
+    return;
+  }
+
+  ImGui::Spacing();
+  ImGui::Separator();
+  ImGui::Spacing();
+
+  ImGui::BeginDisabled(!m_editable);
+
+  // Danger-red full-width button (same palette as the modal's confirm).
+  ImGui::PushStyleColor(ImGuiCol_Button, theme::danger);
+  ImGui::PushStyleColor(ImGuiCol_ButtonHovered, theme::v4(240, 110, 114));
+  ImGui::PushStyleColor(ImGuiCol_ButtonActive, theme::v4(210, 70, 75));
+  ImGui::PushStyleColor(ImGuiCol_Text, theme::v4(255, 255, 255));
+  if (ImGui::Button("Delete Asset", ImVec2(ImGui::GetContentRegionAvail().x, 34.0f)))
+  {
+    // Arm the modal and compute the reference count once, now, rather than every frame.
+    m_assetPendingDeletion = record.uuid;
+    m_pendingRefCount = m_onReferenceCount ? m_onReferenceCount(record.uuid) : 0;
+  }
+  ImGui::PopStyleColor(4);
+
+  ImGui::EndDisabled();
+}
+
+void AssetInspector::displayDeleteConfirmationModal(const AssetRecord& record)
+{
+  // Armed only for the currently-shown asset. If the selection changed out from under an armed prompt
+  // (the modal is normally blocking, but be defensive), drop it rather than confirm a stale delete.
+  if (m_assetPendingDeletion != record.uuid)
+  {
+    m_assetPendingDeletion.reset();
+    return;
+  }
+
+  ImGui::OpenPopup("Delete Asset?");
+
+  bool shouldDelete = false;
+
+  if (ImGui::BeginPopupModal("Delete Asset?", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+  {
+    ImGui::TextUnformatted("Are you sure you want to delete");
+    ImGui::SameLine();
+    ImGui::TextColored(theme::accent, "%s", assetDisplay::name(record).c_str());
+    ImGui::SameLine();
+    ImGui::TextUnformatted("?");
+
+    // Deletion always succeeds; any references are left to dangle (the slots show "None") — warn how many.
+    if (m_pendingRefCount > 0)
+    {
+      ImGui::TextColored(theme::scriptAmber, "Referenced by %d object%s - those references will be left empty.",
+                         m_pendingRefCount, m_pendingRefCount == 1 ? "" : "s");
+    }
+
+    ImGui::TextColored(theme::t3, "This action cannot be undone.");
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // Danger-red confirm; neutral cancel (mirrors ObjectGUIManager's delete modal).
+    ImGui::PushStyleColor(ImGuiCol_Button, theme::danger);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, theme::v4(240, 110, 114));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, theme::v4(210, 70, 75));
+    ImGui::PushStyleColor(ImGuiCol_Text, theme::v4(255, 255, 255));
+    if (ImGui::Button("Delete", ImVec2(120, 0)) || ImGui::IsKeyPressed(ImGuiKey_Enter))
+    {
+      shouldDelete = true;
+      ImGui::CloseCurrentPopup();
+    }
+    ImGui::PopStyleColor(4);
+
+    ImGui::SameLine();
+
+    if (ImGui::Button("Cancel", ImVec2(120, 0)) || ImGui::IsKeyPressed(ImGuiKey_Escape))
+    {
+      m_assetPendingDeletion.reset();
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
+  }
+
+  if (shouldDelete)
+  {
+    if (m_onRemove)
+    {
+      m_onRemove(record.uuid);
+    }
+
+    // The selection is cleared by InspectorPanel next frame: the local apply drops the uuid from the
+    // registry, and the panel's stale-asset check clears the slot (the same path a fresh snapshot uses).
+    m_assetPendingDeletion.reset();
+  }
 }

--- a/source/libs/editor/AssetInspector.h
+++ b/source/libs/editor/AssetInspector.h
@@ -2,6 +2,7 @@
 #define ASSETINSPECTOR_H
 
 #include <nlohmann/json_fwd.hpp>
+#include <array>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -20,10 +21,14 @@ class AssetInspector {
 public:
   // Switching the active scene: the same callback the asset browser's scene double-click uses.
   using LoadSceneCallback = std::function<void(const uuids::uuid& sceneUUID)>;
+  // A display-name rename: the EditorApp applies it locally and sends a renameAsset op.
+  using RenameCallback = std::function<void(const uuids::uuid& assetUUID, const std::string& displayName)>;
 
   explicit AssetInspector(std::shared_ptr<GpuAssetCache> assetCache);
 
   void setLoadSceneCallback(LoadSceneCallback callback);
+
+  void setRenameCallback(RenameCallback callback);
 
   // When false (read-only server), the scene inspector's "Load Scene" button is disabled, mirroring the
   // browser's gated double-click.
@@ -40,8 +45,15 @@ private:
   std::shared_ptr<GpuAssetCache> m_assetCache;
 
   LoadSceneCallback m_onLoadScene;
+  RenameCallback m_onRename;
 
   bool m_editable = true;
+
+  // Buffer for the in-place display-name field. Re-seeded (from the effective display name) whenever the
+  // selected asset changes, so an external rename doesn't clobber what the user is typing — matching
+  // ObjectInspector's name buffer.
+  std::array<char, 256> m_nameEditBuffer{};
+  std::optional<uuids::uuid> m_nameEditUUID;
 
   // File metadata (size, image dimensions) for the currently-shown asset, recomputed only when the
   // selected asset changes so the panel isn't hitting disk every frame.
@@ -67,8 +79,9 @@ private:
   bool m_havePrefab = false;
   PrefabNode m_prefabRoot;
 
-  // Display name + uuid + path/source rows common to every asset type.
-  void displayHeader(const AssetRecord& record) const;
+  // Display name (an editable rename field for the flat file assets, gated on editable; read-only text for
+  // scenes) + uuid + path/source rows common to every asset type.
+  void displayHeader(const AssetRecord& record);
 
   // Refreshes the file-metadata cache above for `record` (no-op work when its file isn't reachable).
   void refreshMeta(const AssetRecord& record);

--- a/source/libs/editor/AssetInspector.h
+++ b/source/libs/editor/AssetInspector.h
@@ -23,12 +23,21 @@ public:
   using LoadSceneCallback = std::function<void(const uuids::uuid& sceneUUID)>;
   // A display-name rename: the EditorApp applies it locally and sends a renameAsset op.
   using RenameCallback = std::function<void(const uuids::uuid& assetUUID, const std::string& displayName)>;
+  // A delete: the EditorApp applies it locally and sends a removeAsset op.
+  using RemoveCallback = std::function<void(const uuids::uuid& assetUUID)>;
+  // How many objects (across the replicated scenes + prefab bodies) reference an asset by uuid, shown in
+  // the delete-confirmation modal. Computed by the EditorApp, which owns the scenes and the registry.
+  using ReferenceCountCallback = std::function<int(const uuids::uuid& assetUUID)>;
 
   explicit AssetInspector(std::shared_ptr<GpuAssetCache> assetCache);
 
   void setLoadSceneCallback(LoadSceneCallback callback);
 
   void setRenameCallback(RenameCallback callback);
+
+  void setRemoveCallback(RemoveCallback callback);
+
+  void setReferenceCountCallback(ReferenceCountCallback callback);
 
   // When false (read-only server), the scene inspector's "Load Scene" button is disabled, mirroring the
   // browser's gated double-click.
@@ -46,6 +55,8 @@ private:
 
   LoadSceneCallback m_onLoadScene;
   RenameCallback m_onRename;
+  RemoveCallback m_onRemove;
+  ReferenceCountCallback m_onReferenceCount;
 
   bool m_editable = true;
 
@@ -54,6 +65,11 @@ private:
   // ObjectInspector's name buffer.
   std::array<char, 256> m_nameEditBuffer{};
   std::optional<uuids::uuid> m_nameEditUUID;
+
+  // The asset awaiting delete confirmation (set by the "Delete Asset" button). While set, the modal is
+  // shown; m_pendingRefCount is the object count computed once when the prompt opened.
+  std::optional<uuids::uuid> m_assetPendingDeletion;
+  int m_pendingRefCount = 0;
 
   // File metadata (size, image dimensions) for the currently-shown asset, recomputed only when the
   // selected asset changes so the panel isn't hitting disk every frame.
@@ -102,6 +118,13 @@ private:
   void displayPrefabBody();
 
   void displayPrefabNode(const PrefabNode& node, bool root) const;
+
+  // A danger "Delete Asset" button (flat file assets only, gated on editable) that arms the modal below.
+  void displayDeleteButton(const AssetRecord& record);
+
+  // The "Delete Asset?" confirmation modal for m_assetPendingDeletion, warning how many objects reference
+  // it (references are left to dangle — see ROADMAP B1). Confirming fires the remove callback.
+  void displayDeleteConfirmationModal(const AssetRecord& record);
 
   // Walks one serialized-Object JSON node into a PrefabNode (recursing into children).
   static PrefabNode parsePrefabNode(const nlohmann::json& node);

--- a/source/libs/editor/InspectorPanel.cpp
+++ b/source/libs/editor/InspectorPanel.cpp
@@ -50,6 +50,11 @@ void InspectorPanel::setLoadSceneCallback(std::function<void(const uuids::uuid& 
   m_assetInspector->setLoadSceneCallback(std::move(callback));
 }
 
+void InspectorPanel::setRenameAssetCallback(std::function<void(const uuids::uuid& assetUUID, const std::string& displayName)> callback)
+{
+  m_assetInspector->setRenameCallback(std::move(callback));
+}
+
 void InspectorPanel::displayGui(const ObjectManager* objectManager, const std::optional<uuids::uuid>& activeSceneUUID)
 {
   ImGui::Begin("Inspector");

--- a/source/libs/editor/InspectorPanel.cpp
+++ b/source/libs/editor/InspectorPanel.cpp
@@ -55,6 +55,16 @@ void InspectorPanel::setRenameAssetCallback(std::function<void(const uuids::uuid
   m_assetInspector->setRenameCallback(std::move(callback));
 }
 
+void InspectorPanel::setRemoveAssetCallback(std::function<void(const uuids::uuid& assetUUID)> callback)
+{
+  m_assetInspector->setRemoveCallback(std::move(callback));
+}
+
+void InspectorPanel::setAssetReferenceCountCallback(std::function<int(const uuids::uuid& assetUUID)> callback)
+{
+  m_assetInspector->setReferenceCountCallback(std::move(callback));
+}
+
 void InspectorPanel::displayGui(const ObjectManager* objectManager, const std::optional<uuids::uuid>& activeSceneUUID)
 {
   ImGui::Begin("Inspector");

--- a/source/libs/editor/InspectorPanel.h
+++ b/source/libs/editor/InspectorPanel.h
@@ -49,6 +49,10 @@ public:
   // Forwarded to the asset inspector's scene view (same callback the asset browser uses).
   void setLoadSceneCallback(std::function<void(const uuids::uuid& sceneUUID)> callback);
 
+  // Forwarded to the asset inspector's rename field (a display-name override; EditorApp applies locally
+  // and sends a renameAsset op).
+  void setRenameAssetCallback(std::function<void(const uuids::uuid& assetUUID, const std::string& displayName)> callback);
+
   // objectManager may be null (no scene loaded yet): the window is still drawn (empty) so it stays
   // present/dockable instead of popping in and out. activeSceneUUID is the currently loaded scene, used
   // by the scene inspector's is-active indicator (nullopt when no scene is loaded).

--- a/source/libs/editor/InspectorPanel.h
+++ b/source/libs/editor/InspectorPanel.h
@@ -53,6 +53,12 @@ public:
   // and sends a renameAsset op).
   void setRenameAssetCallback(std::function<void(const uuids::uuid& assetUUID, const std::string& displayName)> callback);
 
+  // Forwarded to the asset inspector's delete flow: the remove op (local apply + removeAsset) and the
+  // reference-count query the confirmation modal shows.
+  void setRemoveAssetCallback(std::function<void(const uuids::uuid& assetUUID)> callback);
+
+  void setAssetReferenceCountCallback(std::function<int(const uuids::uuid& assetUUID)> callback);
+
   // objectManager may be null (no scene loaded yet): the window is still drawn (empty) so it stays
   // present/dockable instead of popping in and out. activeSceneUUID is the currently loaded scene, used
   // by the scene inspector's is-active indicator (nullopt when no scene is loaded).

--- a/source/libs/protocol/Protocol.h
+++ b/source/libs/protocol/Protocol.h
@@ -34,10 +34,12 @@ enum class MessageType : uint8_t {
   sceneStatus,   // server -> client: current scene lifecycle state ({ status: "running"|"paused"|"stopped" })
   objectSpawned, // server -> client: one object created at runtime (Object::pack); spliced into the scene
   objectDestroyed, // server -> client: uuid of an object removed at runtime; the client drops it from the scene
-  playerSlot     // server -> all: (nonce uint64, slot int32) — the player slot bound to the client whose
+  playerSlot,    // server -> all: (nonce uint64, slot int32) — the player slot bound to the client whose
                  // join carried this nonce. Broadcast + nonce correlation (no per-connection send path):
                  // every client hears it, only the one whose join nonce matches keeps it (Phase 4.4).
-  // editComponent/sceneEdit/sceneControl/loadProject/addAsset are the editor's mutation path; the server
+  renameAsset,   // editor -> server: set an asset's display-name override (replication::packRenameAsset); server re-snapshots
+  removeAsset    // editor -> server: drop an asset record by uuid (replication::packRemoveAsset); server re-snapshots
+  // editComponent/sceneEdit/sceneControl/loadProject/addAsset/renameAsset/removeAsset are the editor's mutation path; the server
   // only honors them from a connection it authorized as Role::editor at the transport handshake (which
   // carries role + token out of band, ahead of any message here), and only on an edit-mode server. An
   // editor connecting to a non-edit server is admitted read-only (it views but cannot mutate).


### PR DESCRIPTION
This pull request adds asset rename and delete functionality to the editor and server, allowing assets to be renamed (display-name override) or removed, with changes applied locally for instant feedback and then sent to the server for authoritative application and snapshot. It also ensures that asset display names are serialized and loaded correctly, and implements reference counting for safe asset deletion warnings in the editor. Server and data replication logic are updated to support these new asset mutation commands.

**Editor and Asset Browser Enhancements:**
* The editor now supports renaming (display-name only) and deleting assets from the asset browser, with instant local feedback and authoritative server synchronization. The delete operation is guarded by a reference count warning, scanning all scenes and prefabs for references to the asset. [[1]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R153-R209) [[2]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R260-R262) [[3]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R70-R117)
* The asset browser and inspector panels are wired to the new callbacks for rename, delete, and reference counting.

**Server and Networking Support:**
* The server recognizes and processes new `renameAsset` and `removeAsset` messages, applying the changes and broadcasting updated snapshots. [[1]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR249-R250) [[2]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR289-R296) [[3]](diffhunk://#diff-b1725094ceeaffe6bc8743ed9d66efaf36b7b565b80b69374599a332725d073dR503-R543) [[4]](diffhunk://#diff-59a6facf8f8f4ca802ec9e46466dd86b4d1fc813aeaea6dfbce95fae1f4f9292R106-R109)

**Data Replication and Serialization:**
* New helpers for building, packing, unpacking, and applying rename and remove asset operations are added to the replication layer, mirroring the add asset flow. [[1]](diffhunk://#diff-8d3d6c099c8fc01ec0c3687fcf11404380f958f32ffa16ae506bdf5f39312d1aR564-R640) [[2]](diffhunk://#diff-5125260ab551a8e4b9b0007faf66bd97c8ee3331c9788e5076589d48ddbf93d4R101-R120)
* The `AssetRegistry` now supports renaming (display-name override only) and removing assets, updating both internal maps and serialized output.
* Asset display names are now serialized and deserialized for all asset types, ensuring persistence of overrides across save/load cycles. [[1]](diffhunk://#diff-30ac22f3f2f016f61db726d4319f486618162042ec15dff39647feff25967abeR131-R154) [[2]](diffhunk://#diff-30ac22f3f2f016f61db726d4319f486618162042ec15dff39647feff25967abeL118-R167) [[3]](diffhunk://#diff-30ac22f3f2f016f61db726d4319f486618162042ec15dff39647feff25967abeL142-R188) [[4]](diffhunk://#diff-30ac22f3f2f016f61db726d4319f486618162042ec15dff39647feff25967abeL154-R201) [[5]](diffhunk://#diff-30ac22f3f2f016f61db726d4319f486618162042ec15dff39647feff25967abeL167-R215) [[6]](diffhunk://#diff-30ac22f3f2f016f61db726d4319f486618162042ec15dff39647feff25967abeL187-R236)

**Documentation:**
* The agent and replication documentation is updated to describe the new asset mutation operations, their local-apply-then-send shape, and the semantics of rename (display-only) and delete (references dangle, no cascade). [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L34-R34) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L91-R104)