### PR TITLE
Implement TransientObject for detached prefab editing and updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 | `source/libs/data/` | `ECS3DData` — the foundation. Component **data** (Transform, RigidBody, ModelRenderer, LightRenderer, Colliders, Script, PlayerController, Camera), `Object`/`ObjectManager`, scenes, `AssetRegistry` (incl. prefab bodies), `ComponentRegistry`, `ProjectSerializer` (JSON file save/load) / `ProjectPacker` (binary wire snapshot), `Replication`. **No Vulkan, no ImGui.** |
 | `source/libs/sim/` | `ECS3DSim` — `PhysicsSystem` (integration, forces, response) and `CollisionSystem` (sweep-and-prune + GJK/EPA under `collisions/`). Operates on `ECS3DData` via accessors. OpenMP if available. |
 | `source/libs/render/` | `ECS3DRender` — `RenderSystem` (draws models/lights, pick feedback, selection highlight, collider gizmos, and drives the `vke::Camera`/`Renderer3D` view from the scene's active `Camera` component), `GpuAssetCache` (UUID → `vke` GPU objects), `InputCapture`. Depends on `ECS3DData` + `VulkanEngine`. |
-| `source/libs/editor/` | `ECS3DEditorLib` — ImGui editing UI: `ComponentEditor` (per-type handlers), `ObjectGUIManager` (object tree), `InspectorPanel` (the "Inspector" window — per-selection-kind dispatch) delegating the object kind to `ObjectInspector` and the asset kind to `AssetInspector` (per-`AssetType` views — read-only detail plus a display-name rename field and a delete button with a reference-count warning for the flat file assets), `EditorSelection` (shared kind-tagged selection slot, `Selection.h`), `AssetBrowserPanel`, `AssetDisplay` (shared asset label/name/icon/color rules, header-only), `SaveUI`, `GuiComponents`. Depends on `ECS3DData` + `ECS3DRender` + `nfd`. |
+| `source/libs/editor/` | `ECS3DEditorLib` — ImGui editing UI: `ComponentEditor` (per-type handlers), `ObjectGUIManager` (object tree), `InspectorPanel` (the "Inspector" window — per-selection-kind dispatch) delegating the object kind to `ObjectInspector` and the asset kind to `AssetInspector` (per-`AssetType` views — read-only detail plus a display-name rename field and a delete button with a reference-count warning for the flat file assets; the **Prefab body is editable** — deserialized into a detached `TransientObject` and edited by a reused `ObjectInspector`, see Prefabs), `EditorSelection` (shared kind-tagged selection slot, `Selection.h`), `AssetBrowserPanel`, `AssetDisplay` (shared asset label/name/icon/color rules, header-only), `SaveUI`, `GuiComponents`. Depends on `ECS3DData` + `ECS3DRender` + `nfd`. |
 | `source/libs/net/` | `ECS3DNet` — `NetServer`/`NetClient`/`MessageQueue`/`ServerProcess` (C++), plus the `Transport/` C# assembly (`ECS3DNetTransport`, TCP + WebSocket backends). |
 | `source/libs/scripting/` | `ECS3DScripting` — `ScriptSystem`/`ScriptEngine` + native `bindings/` (Transform, RigidBody, InputUtils, World, Camera; `InputState`, `BindingContext`), plus the `ScriptBridge/` C# assembly and example `UserScripts/`. |
 | `source/libs/clrHost/` | `ECS3DClrHost` — `ManagedHost` boots CoreCLR and hands out managed statics as native fn ptrs. Owns the CMake helpers (`cmake/ECS3DManaged.cmake`, `FindDotnet.cmake`, `loadCS.cmake`). |
@@ -123,7 +123,15 @@ reaches the registry through **`BindingContext::setAssetRegistry`**, injected on
 sim's raycast/overlap statics. **Instances are detached copies** — nothing records which prefab an object came
 from, so overrides and prefab→instance propagation don't exist (deliberately deferred; see `ROADMAP.md`).
 `DefaultProject` defines its `Block`/`Rigid Block`/`Sphere`/`Player` bodies once, registers them as prefabs
-with stable uuids, and builds its scenes by instancing them.
+with stable uuids, and builds its scenes by instancing them. **Editing a prefab's contents** happens in the
+Inspector: `AssetInspector` deserializes the body into a `TransientObject` (editor lib) — a detached `Object`
+living in a private scratch `ObjectManager` never wired to a scene/`SceneManager`/replication, uuids
+preserved so the body is stable across edits — and draws it with a reused `ObjectInspector`. Its edits apply
+locally (value edits in place; structural edits deferred past `display()` then `applySceneEdit`'d, so the
+component map isn't mutated mid-iteration), and each change re-serializes the body and re-registers it under
+the prefab's existing name via the `addAsset` op (updating the body in place, keeping the uuid — the same
+"Save as Prefab" path), which re-snapshots. `TransientObject::markSynced` records the just-sent body so the
+local-apply/snapshot echo doesn't rebuild the object mid-edit.
 
 **Transport / CLR.** `Protocol.h` defines the format; `NetServer`/`NetClient` own it in C++ and hand
 `ECS3DNetTransport` (C#) opaque `(type byte, payload)` pairs. `ManagedHost` boots CoreCLR and resolves

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,11 @@ locally (value edits in place; structural edits deferred past `display()` then `
 component map isn't mutated mid-iteration), and each change re-serializes the body and re-registers it under
 the prefab's existing name via the `addAsset` op (updating the body in place, keeping the uuid — the same
 "Save as Prefab" path), which re-snapshots. `TransientObject::markSynced` records the just-sent body so the
-local-apply/snapshot echo doesn't rebuild the object mid-edit.
+local-apply/snapshot echo doesn't rebuild the object mid-edit. Because that body update makes the server
+re-snapshot the **whole project** (unlike a live object's cheap `editComponent` rebroadcast), the send is
+**coalesced**: edits mutate the detached object live for instant local feedback but only flush to the network
+once no ImGui widget is active (drag released) or the selection changes, so a whole slider drag is one
+snapshot rather than one per frame.
 
 **Transport / CLR.** `Protocol.h` defines the format; `NetServer`/`NetClient` own it in C++ and hand
 `ECS3DNetTransport` (C#) opaque `(type byte, payload)` pairs. `ManagedHost` boots CoreCLR and resolves

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -251,7 +251,20 @@ EditorApp::EditorApp(LaunchOptions options)
     m_netClient->send(message);
   };
 
-  m_inspectorPanel = std::make_shared<InspectorPanel>(m_componentEditor, m_assetCache);
+  // A prefab body edit from the inspector: re-register the prefab under its existing name, which updates the
+  // body in place and keeps the uuid (the same path "Save as Prefab" over an existing name takes). Same
+  // local-apply-then-send addAsset shape as everything else.
+  const auto updatePrefabBody = [addAsset](const uuids::uuid& assetUUID, const std::string& name,
+                                           const std::string& body) {
+    addAsset({
+      { "assetType", "prefab" },
+      { "uuid", uuids::to_string(assetUUID) },
+      { "name", name },
+      { "body", body }
+    });
+  };
+
+  m_inspectorPanel = std::make_shared<InspectorPanel>(m_componentEditor, m_componentRegistry, m_assetCache);
   m_inspectorPanel->setSelection(m_selection);
   m_inspectorPanel->setAssetRegistry(m_assetRegistry.get());
   m_inspectorPanel->setEditCallback(editComponent);
@@ -260,6 +273,7 @@ EditorApp::EditorApp(LaunchOptions options)
   m_inspectorPanel->setRenameAssetCallback(renameAsset);
   m_inspectorPanel->setRemoveAssetCallback(removeAsset);
   m_inspectorPanel->setAssetReferenceCountCallback(countAssetReferences);
+  m_inspectorPanel->setUpdatePrefabBodyCallback(updatePrefabBody);
 
   m_assetBrowser = std::make_shared<AssetBrowserPanel>(m_assetRegistry.get(), m_assetCache);
   m_assetBrowser->setSelection(m_selection);

--- a/source/libs/editor/AssetInspector.cpp
+++ b/source/libs/editor/AssetInspector.cpp
@@ -1,8 +1,12 @@
 #include "AssetInspector.h"
 #include "AssetDisplay.h"
 #include "GuiComponents.h"
+#include "ObjectInspector.h"
+#include "TransientObject.h"
 #include <GpuAssetCache.h>
+#include <Replication.h>
 #include <assets/AssetRegistry.h>
+#include <objects/Object.h>
 #include <VulkanEngine/VulkanEngine.h>
 #include <VulkanEngine/components/window/Window.h>
 #include <VulkanEngine/components/assets/textures/Texture2D.h>
@@ -18,9 +22,30 @@
 #include <string>
 #include <utility>
 
-AssetInspector::AssetInspector(std::shared_ptr<GpuAssetCache> assetCache)
-  : m_assetCache(std::move(assetCache))
-{}
+AssetInspector::AssetInspector(std::shared_ptr<GpuAssetCache> assetCache,
+                               std::shared_ptr<ComponentRegistry> componentRegistry,
+                               std::shared_ptr<ComponentEditor> componentEditor)
+  : m_assetCache(std::move(assetCache)),
+    m_componentRegistry(std::move(componentRegistry)),
+    m_prefabBody(std::make_unique<TransientObject>(m_componentRegistry)),
+    m_prefabInspector(std::make_unique<ObjectInspector>(std::move(componentEditor)))
+{
+  // The reused inspector edits a detached object, so its edits must apply locally rather than travel to the
+  // server. A value edit already mutated the component in place — just note it. A structural edit is queued
+  // and applied after display() returns (applying it now would mutate the component map mid-iteration).
+  m_prefabInspector->setEditCallback([this](const uuids::uuid&, const std::shared_ptr<Component>&) {
+    m_prefabValueEdited = true;
+  });
+  m_prefabInspector->setSceneEditCallback([this](const nlohmann::json& edit) {
+    m_pendingPrefabEdits.push_back(edit);
+  });
+
+  // No viewport highlight for a detached prefab body.
+  m_prefabInspector->setShowHighlightToggle(false);
+}
+
+// Defined here (not defaulted in the header) so the inspector/body unique_ptrs see their complete types.
+AssetInspector::~AssetInspector() = default;
 
 void AssetInspector::setLoadSceneCallback(LoadSceneCallback callback)
 {
@@ -42,6 +67,16 @@ void AssetInspector::setReferenceCountCallback(ReferenceCountCallback callback)
   m_onReferenceCount = std::move(callback);
 }
 
+void AssetInspector::setUpdatePrefabBodyCallback(UpdatePrefabBodyCallback callback)
+{
+  m_onUpdatePrefabBody = std::move(callback);
+}
+
+void AssetInspector::setAssetRegistry(const AssetRegistry* registry)
+{
+  m_prefabInspector->setAssetRegistry(registry);
+}
+
 namespace {
   // A display-name rename is a display-only override the AssetRegistry packs (see AssetRegistry::pack): it
   // survives a snapshot only for the flat file assets. A Scene record is regenerated from the SceneManager
@@ -56,6 +91,7 @@ namespace {
 void AssetInspector::setEditable(const bool editable)
 {
   m_editable = editable;
+  m_prefabInspector->setEditable(editable);
 }
 
 void AssetInspector::displayTypeChip(const AssetRecord& record) const
@@ -83,7 +119,7 @@ void AssetInspector::display(const AssetRecord& record, const std::optional<uuid
     case AssetType::Model:   displayModelBody(record);   break;
     case AssetType::Script:  displayScriptBody();         break;
     case AssetType::Scene:   displaySceneBody(record, activeSceneUUID); break;
-    case AssetType::Prefab:  displayPrefabBody();         break;
+    case AssetType::Prefab:  displayPrefabBody(record);   break;
     default: break;
   }
 
@@ -150,24 +186,9 @@ void AssetInspector::refreshMeta(const AssetRecord& record)
   m_indexCount = 0;
   m_haveScriptSource = false;
   m_scriptSource.clear();
-  m_havePrefab = false;
-  m_prefabRoot = {};
 
-  // Prefabs carry their contents inline (record.body), not as a file — walk the JSON into a read-only
-  // tree here (once per selection) rather than instantiating an ObjectManager.
-  if (record.type == AssetType::Prefab)
-  {
-    if (const auto body = nlohmann::json::parse(record.body, nullptr, false);
-        !body.is_discarded() && body.is_object())
-    {
-      m_prefabRoot = parsePrefabNode(body);
-      m_havePrefab = true;
-    }
-    return;
-  }
-
-  // Only file-backed types have a path on disk; scenes carry their name there instead.
-  if (record.type == AssetType::Scene || record.path.empty())
+  // Only file-backed types have a path on disk; scenes carry their name there, prefabs their inline body.
+  if (record.type == AssetType::Scene || record.type == AssetType::Prefab || record.path.empty())
   {
     return;
   }
@@ -383,89 +404,53 @@ void AssetInspector::displaySceneBody(const AssetRecord& record, const std::opti
   ImGui::EndDisabled();
 }
 
-AssetInspector::PrefabNode AssetInspector::parsePrefabNode(const nlohmann::json& node)
-{
-  PrefabNode result;
-  result.name = node.value("name", std::string("(unnamed)"));
-
-  if (const auto components = node.find("components"); components != node.end() && components->is_array())
-  {
-    for (const auto& component : *components)
-    {
-      result.components.push_back(component.value("type", std::string("Component")));
-    }
-  }
-
-  if (const auto children = node.find("children"); children != node.end() && children->is_array())
-  {
-    for (const auto& child : *children)
-    {
-      if (child.is_object())
-      {
-        result.children.push_back(parsePrefabNode(child));
-      }
-    }
-  }
-
-  return result;
-}
-
-void AssetInspector::displayPrefabBody()
+void AssetInspector::displayPrefabBody(const AssetRecord& record)
 {
   ImGui::Spacing();
   gc::sectionLabel("Contents");
   ImGui::Spacing();
 
-  if (!m_havePrefab)
+  // (Re)build the detached object when the body changed under us (a different prefab selected, or an
+  // external snapshot). A local edit below re-serializes and markSyncs, so its own echo won't rebuild.
+  m_prefabBody->syncFromBody(record.body);
+
+  const auto& object = m_prefabBody->object();
+  if (!object)
   {
-    // Empty/malformed body (e.g. an older or hand-edited record) — nothing to walk.
+    // Empty/malformed body (an older or hand-edited record) — nothing to deserialize.
     gc::dashedBox("Prefab body unavailable");
     return;
   }
 
-  displayPrefabNode(m_prefabRoot, true);
-}
+  // Draw the body with the same component editors an object uses. The wired callbacks collect structural
+  // edits and flag value edits rather than sending them; apply + re-serialize once display has returned so
+  // a structural edit doesn't mutate the component map ObjectInspector::display is iterating.
+  m_pendingPrefabEdits.clear();
+  m_prefabValueEdited = false;
 
-void AssetInspector::displayPrefabNode(const PrefabNode& node, const bool root) const
-{
-  ImGui::PushID(&node);
+  m_prefabInspector->display(object);
 
-  ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_OpenOnArrow;
-  if (root)
+  bool changed = m_prefabValueEdited;
+  if (auto* manager = m_prefabBody->manager())
   {
-    flags |= ImGuiTreeNodeFlags_DefaultOpen;
-  }
-  if (node.children.empty())
-  {
-    flags |= ImGuiTreeNodeFlags_Leaf;
-  }
-
-  if (ImGui::TreeNodeEx(node.name.c_str(), flags))
-  {
-    // Component types on one muted line, indented under the object.
-    if (!node.components.empty())
+    for (const auto& edit : m_pendingPrefabEdits)
     {
-      std::string types;
-      for (size_t i = 0; i < node.components.size(); ++i)
-      {
-        if (i != 0)
-        {
-          types += ", ";
-        }
-        types += node.components[i];
-      }
-      ImGui::TextColored(theme::t3, "%s", types.c_str());
+      replication::applySceneEdit(*manager, edit);
+      changed = true;
     }
-
-    for (const auto& child : node.children)
-    {
-      displayPrefabNode(child, false);
-    }
-
-    ImGui::TreePop();
   }
+  m_pendingPrefabEdits.clear();
 
-  ImGui::PopID();
+  if (changed && m_onUpdatePrefabBody)
+  {
+    // Send the updated body keyed by the prefab's name (record.path): re-registering an existing name
+    // updates the body in place and keeps the uuid — the same path "Save as Prefab" over an existing name
+    // takes. markSynced so the resulting registry update (and the server's snapshot echo) doesn't rebuild
+    // the object out from under the ongoing edit.
+    const auto newBody = m_prefabBody->serialize();
+    m_onUpdatePrefabBody(record.uuid, record.path, newBody);
+    m_prefabBody->markSynced(newBody);
+  }
 }
 
 void AssetInspector::displayDeleteButton(const AssetRecord& record)

--- a/source/libs/editor/AssetInspector.cpp
+++ b/source/libs/editor/AssetInspector.cpp
@@ -31,10 +31,11 @@ AssetInspector::AssetInspector(std::shared_ptr<GpuAssetCache> assetCache,
     m_prefabInspector(std::make_unique<ObjectInspector>(std::move(componentEditor)))
 {
   // The reused inspector edits a detached object, so its edits must apply locally rather than travel to the
-  // server. A value edit already mutated the component in place — just note it. A structural edit is queued
-  // and applied after display() returns (applying it now would mutate the component map mid-iteration).
+  // server. A value edit already mutated the component in place — just mark the body dirty. A structural
+  // edit is queued and applied after display() returns (applying it now would mutate the component map
+  // mid-iteration). Neither sends immediately; displayPrefabBody coalesces the send (see m_prefabBodyDirty).
   m_prefabInspector->setEditCallback([this](const uuids::uuid&, const std::shared_ptr<Component>&) {
-    m_prefabValueEdited = true;
+    m_prefabBodyDirty = true;
   });
   m_prefabInspector->setSceneEditCallback([this](const nlohmann::json& edit) {
     m_pendingPrefabEdits.push_back(edit);
@@ -410,9 +411,21 @@ void AssetInspector::displayPrefabBody(const AssetRecord& record)
   gc::sectionLabel("Contents");
   ImGui::Spacing();
 
+  // Switching to a different prefab with an edit still pending: flush it against the asset it belongs to
+  // (m_prefabRecord*, still the old one) before syncFromBody rebuilds to the new body below.
+  if (m_prefabBodyDirty && record.uuid != m_prefabRecordUUID)
+  {
+    flushPrefabBody();
+  }
+
   // (Re)build the detached object when the body changed under us (a different prefab selected, or an
-  // external snapshot). A local edit below re-serializes and markSyncs, so its own echo won't rebuild.
-  m_prefabBody->syncFromBody(record.body);
+  // external snapshot). A flushed edit markSyncs the sent body, so its own echo won't rebuild.
+  if (m_prefabBody->syncFromBody(record.body))
+  {
+    // The pending edit (if any) belongs to whatever we just loaded.
+    m_prefabRecordUUID = record.uuid;
+    m_prefabRecordName = record.path;
+  }
 
   const auto& object = m_prefabBody->object();
   if (!object)
@@ -423,34 +436,51 @@ void AssetInspector::displayPrefabBody(const AssetRecord& record)
   }
 
   // Draw the body with the same component editors an object uses. The wired callbacks collect structural
-  // edits and flag value edits rather than sending them; apply + re-serialize once display has returned so
-  // a structural edit doesn't mutate the component map ObjectInspector::display is iterating.
+  // edits and mark value edits dirty rather than sending them; apply the structural ones once display has
+  // returned so they don't mutate the component map ObjectInspector::display is iterating.
   m_pendingPrefabEdits.clear();
-  m_prefabValueEdited = false;
 
   m_prefabInspector->display(object);
 
-  bool changed = m_prefabValueEdited;
   if (auto* manager = m_prefabBody->manager())
   {
     for (const auto& edit : m_pendingPrefabEdits)
     {
       replication::applySceneEdit(*manager, edit);
-      changed = true;
+      m_prefabBodyDirty = true;
     }
   }
   m_pendingPrefabEdits.clear();
 
-  if (changed && m_onUpdatePrefabBody)
+  // Coalesce the send: a prefab body update makes the server re-snapshot the whole project, so hold it
+  // until the user isn't actively dragging/typing a widget. The detached object already reflects the edit,
+  // so local feedback stays instant; the network sees one update per interaction instead of per frame.
+  if (m_prefabBodyDirty && !ImGui::IsAnyItemActive())
   {
-    // Send the updated body keyed by the prefab's name (record.path): re-registering an existing name
-    // updates the body in place and keeps the uuid — the same path "Save as Prefab" over an existing name
-    // takes. markSynced so the resulting registry update (and the server's snapshot echo) doesn't rebuild
-    // the object out from under the ongoing edit.
-    const auto newBody = m_prefabBody->serialize();
-    m_onUpdatePrefabBody(record.uuid, record.path, newBody);
-    m_prefabBody->markSynced(newBody);
+    flushPrefabBody();
   }
+}
+
+void AssetInspector::flushPrefabBody()
+{
+  if (!m_prefabBodyDirty)
+  {
+    return;
+  }
+
+  m_prefabBodyDirty = false;
+
+  if (!m_onUpdatePrefabBody || !m_prefabBody->object())
+  {
+    return;
+  }
+
+  // Re-register under the prefab's name (m_prefabRecordName): re-registering an existing name updates the
+  // body in place and keeps the uuid — the same path "Save as Prefab" over an existing name takes.
+  // markSynced so the resulting registry update (and the server's snapshot echo) doesn't rebuild the object.
+  const auto newBody = m_prefabBody->serialize();
+  m_onUpdatePrefabBody(m_prefabRecordUUID, m_prefabRecordName, newBody);
+  m_prefabBody->markSynced(newBody);
 }
 
 void AssetInspector::displayDeleteButton(const AssetRecord& record)

--- a/source/libs/editor/AssetInspector.h
+++ b/source/libs/editor/AssetInspector.h
@@ -83,13 +83,23 @@ private:
   bool m_editable = true;
 
   // The detached prefab body being edited + the object inspector that draws its component editors, reused
-  // verbatim from the Object kind. The inspector's callbacks feed the two buffers below rather than the
-  // network: structural edits are deferred (applied after its display returns, since applying mid-display
-  // would invalidate the component map it iterates), value edits just flag a re-serialize.
+  // verbatim from the Object kind. The inspector's callbacks feed the buffers below rather than the network:
+  // structural edits are deferred (applied after its display returns, since applying mid-display would
+  // invalidate the component map it iterates); value edits just mark the body dirty. Both apply to the
+  // detached object immediately (instant local feedback), but the SEND is coalesced — see m_prefabBodyDirty.
   std::unique_ptr<TransientObject> m_prefabBody;
   std::unique_ptr<ObjectInspector> m_prefabInspector;
   std::vector<nlohmann::json> m_pendingPrefabEdits;
-  bool m_prefabValueEdited = false;
+
+  // Unlike a live object's component edit (a small editComponent message the server just rebroadcasts), a
+  // prefab body update is an addAsset that makes the server re-snapshot the whole project. Sending one per
+  // drag frame swamps every view, so edits are coalesced: they mutate the detached object live, set this
+  // flag, and are only serialized + sent once the user stops interacting (no active widget) or switches
+  // selection — turning a whole slider drag into a single body update. m_prefabRecord* records which asset
+  // the pending edit belongs to, so a flush triggered by a selection change sends it under the right key.
+  bool m_prefabBodyDirty = false;
+  uuids::uuid m_prefabRecordUUID{};
+  std::string m_prefabRecordName;
 
   // Buffer for the in-place display-name field. Re-seeded (from the effective display name) whenever the
   // selected asset changes, so an external rename doesn't clobber what the user is typing — matching
@@ -136,9 +146,14 @@ private:
   void displaySceneBody(const AssetRecord& record, const std::optional<uuids::uuid>& activeSceneUUID);
 
   // Editable prefab contents: syncs the detached TransientObject from the record body, draws it with the
-  // reused ObjectInspector, then applies any deferred edit and sends the re-serialized body. Read-only
-  // (disabled editors) when !m_editable. Shows a fallback when the body is missing/malformed.
+  // reused ObjectInspector, applies any deferred edit to the detached object, and flushes a coalesced body
+  // update when the user stops interacting. Read-only (disabled editors) when !m_editable. Shows a fallback
+  // when the body is missing/malformed.
   void displayPrefabBody(const AssetRecord& record);
+
+  // Send the pending prefab body edit (if any) under the asset it belongs to (m_prefabRecord*), then clear
+  // the dirty flag. Serializes the detached object and re-registers it via UpdatePrefabBodyCallback.
+  void flushPrefabBody();
 
   // A danger "Delete Asset" button (flat file assets only, gated on editable) that arms the modal below.
   void displayDeleteButton(const AssetRecord& record);

--- a/source/libs/editor/AssetInspector.h
+++ b/source/libs/editor/AssetInspector.h
@@ -11,12 +11,18 @@
 #include <uuid.h>
 
 struct AssetRecord;
+class AssetRegistry;
+class ComponentRegistry;
+class ComponentEditor;
 class GpuAssetCache;
+class ObjectInspector;
+class TransientObject;
 
 // The Inspector's renderer for the Asset selection kind: a common header (type chip, display name, uuid,
-// path/source) shared by every asset type, plus a per-type body. Read-only in Phase 2 — there is no
-// protocol for asset mutation yet. Peer to ObjectInspector behind InspectorPanel's per-selection-kind
-// dispatch.
+// path/source) shared by every asset type, plus a per-type body. Most views are read-only; the Prefab body
+// is editable (Phase 4) — its contents are deserialized into a detached TransientObject and edited with the
+// same component editors an object uses (a reused ObjectInspector), each edit re-serialized and sent as an
+// asset body update. Peer to ObjectInspector behind InspectorPanel's per-selection-kind dispatch.
 class AssetInspector {
 public:
   // Switching the active scene: the same callback the asset browser's scene double-click uses.
@@ -28,8 +34,16 @@ public:
   // How many objects (across the replicated scenes + prefab bodies) reference an asset by uuid, shown in
   // the delete-confirmation modal. Computed by the EditorApp, which owns the scenes and the registry.
   using ReferenceCountCallback = std::function<int(const uuids::uuid& assetUUID)>;
+  // A prefab body edit: the EditorApp re-registers the prefab under its existing name (which updates the
+  // body in place, keeping the uuid — the "Save as Prefab" over an existing name path) and re-snapshots.
+  using UpdatePrefabBodyCallback = std::function<void(const uuids::uuid& assetUUID, const std::string& name,
+                                                      const std::string& body)>;
 
-  explicit AssetInspector(std::shared_ptr<GpuAssetCache> assetCache);
+  AssetInspector(std::shared_ptr<GpuAssetCache> assetCache,
+                 std::shared_ptr<ComponentRegistry> componentRegistry,
+                 std::shared_ptr<ComponentEditor> componentEditor);
+
+  ~AssetInspector();
 
   void setLoadSceneCallback(LoadSceneCallback callback);
 
@@ -39,8 +53,14 @@ public:
 
   void setReferenceCountCallback(ReferenceCountCallback callback);
 
-  // When false (read-only server), the scene inspector's "Load Scene" button is disabled, mirroring the
-  // browser's gated double-click.
+  void setUpdatePrefabBodyCallback(UpdatePrefabBodyCallback callback);
+
+  // The registry backs the reused prefab-body ObjectInspector's script drop zone (resolving a dropped
+  // script asset to its class name). Same pointer the panel hands the object inspector.
+  void setAssetRegistry(const AssetRegistry* registry);
+
+  // When false (read-only server), the scene inspector's "Load Scene" button is disabled (mirroring the
+  // browser's gated double-click) and the prefab body's editors are disabled (read-only inspection).
   void setEditable(bool editable);
 
   // The right-aligned type chip in the panel header, drawn on the current header row.
@@ -52,13 +72,24 @@ public:
 
 private:
   std::shared_ptr<GpuAssetCache> m_assetCache;
+  std::shared_ptr<ComponentRegistry> m_componentRegistry;
 
   LoadSceneCallback m_onLoadScene;
   RenameCallback m_onRename;
   RemoveCallback m_onRemove;
   ReferenceCountCallback m_onReferenceCount;
+  UpdatePrefabBodyCallback m_onUpdatePrefabBody;
 
   bool m_editable = true;
+
+  // The detached prefab body being edited + the object inspector that draws its component editors, reused
+  // verbatim from the Object kind. The inspector's callbacks feed the two buffers below rather than the
+  // network: structural edits are deferred (applied after its display returns, since applying mid-display
+  // would invalidate the component map it iterates), value edits just flag a re-serialize.
+  std::unique_ptr<TransientObject> m_prefabBody;
+  std::unique_ptr<ObjectInspector> m_prefabInspector;
+  std::vector<nlohmann::json> m_pendingPrefabEdits;
+  bool m_prefabValueEdited = false;
 
   // Buffer for the in-place display-name field. Re-seeded (from the effective display name) whenever the
   // selected asset changes, so an external rename doesn't clobber what the user is typing — matching
@@ -85,16 +116,6 @@ private:
   bool m_haveScriptSource = false; // script .cs source read from disk
   std::string m_scriptSource;
 
-  // A prefab body walked into a read-only tree (no ObjectManager instantiation): each node is an object
-  // name + its component type names + child nodes.
-  struct PrefabNode {
-    std::string name;
-    std::vector<std::string> components;
-    std::vector<PrefabNode> children;
-  };
-  bool m_havePrefab = false;
-  PrefabNode m_prefabRoot;
-
   // Display name (an editable rename field for the flat file assets, gated on editable; read-only text for
   // scenes) + uuid + path/source rows common to every asset type.
   void displayHeader(const AssetRecord& record);
@@ -114,10 +135,10 @@ private:
   // Is-active indicator + a "Load Scene" button (reusing LoadSceneCallback, gated on editable).
   void displaySceneBody(const AssetRecord& record, const std::optional<uuids::uuid>& activeSceneUUID);
 
-  // Read-only summary of the prefab body: root name, component types, child object tree.
-  void displayPrefabBody();
-
-  void displayPrefabNode(const PrefabNode& node, bool root) const;
+  // Editable prefab contents: syncs the detached TransientObject from the record body, draws it with the
+  // reused ObjectInspector, then applies any deferred edit and sends the re-serialized body. Read-only
+  // (disabled editors) when !m_editable. Shows a fallback when the body is missing/malformed.
+  void displayPrefabBody(const AssetRecord& record);
 
   // A danger "Delete Asset" button (flat file assets only, gated on editable) that arms the modal below.
   void displayDeleteButton(const AssetRecord& record);
@@ -125,9 +146,6 @@ private:
   // The "Delete Asset?" confirmation modal for m_assetPendingDeletion, warning how many objects reference
   // it (references are left to dangle — see ROADMAP B1). Confirming fires the remove callback.
   void displayDeleteConfirmationModal(const AssetRecord& record);
-
-  // Walks one serialized-Object JSON node into a PrefabNode (recursing into children).
-  static PrefabNode parsePrefabNode(const nlohmann::json& node);
 };
 
 #endif //ASSETINSPECTOR_H

--- a/source/libs/editor/CMakeLists.txt
+++ b/source/libs/editor/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(${PROJECT_NAME}
   ObjectInspector.h
   AssetInspector.cpp
   AssetInspector.h
+  TransientObject.cpp
+  TransientObject.h
   AssetDisplay.h
   Selection.h
   AssetBrowserPanel.cpp

--- a/source/libs/editor/InspectorPanel.cpp
+++ b/source/libs/editor/InspectorPanel.cpp
@@ -10,9 +10,14 @@
 #include <utility>
 
 InspectorPanel::InspectorPanel(std::shared_ptr<ComponentEditor> componentEditor,
+                               std::shared_ptr<ComponentRegistry> componentRegistry,
                                std::shared_ptr<GpuAssetCache> assetCache)
-  : m_objectInspector(std::make_unique<ObjectInspector>(std::move(componentEditor))),
-    m_assetInspector(std::make_unique<AssetInspector>(std::move(assetCache)))
+  // componentEditor is shared by both inspectors (the asset inspector reuses the object editors for the
+  // editable prefab body). m_objectInspector is initialised first (declaration order), so it takes a copy
+  // and the asset inspector moves the last reference.
+  : m_objectInspector(std::make_unique<ObjectInspector>(componentEditor)),
+    m_assetInspector(std::make_unique<AssetInspector>(std::move(assetCache), std::move(componentRegistry),
+                                                      std::move(componentEditor)))
 {}
 
 // Defined here (not defaulted in the header) so the inspector unique_ptrs see their complete types.
@@ -27,6 +32,7 @@ void InspectorPanel::setAssetRegistry(const AssetRegistry* registry)
 {
   m_assetRegistry = registry;
   m_objectInspector->setAssetRegistry(registry);
+  m_assetInspector->setAssetRegistry(registry);
 }
 
 void InspectorPanel::setEditable(const bool editable)
@@ -63,6 +69,11 @@ void InspectorPanel::setRemoveAssetCallback(std::function<void(const uuids::uuid
 void InspectorPanel::setAssetReferenceCountCallback(std::function<int(const uuids::uuid& assetUUID)> callback)
 {
   m_assetInspector->setReferenceCountCallback(std::move(callback));
+}
+
+void InspectorPanel::setUpdatePrefabBodyCallback(std::function<void(const uuids::uuid& assetUUID, const std::string& name, const std::string& body)> callback)
+{
+  m_assetInspector->setUpdatePrefabBodyCallback(std::move(callback));
 }
 
 void InspectorPanel::displayGui(const ObjectManager* objectManager, const std::optional<uuids::uuid>& activeSceneUUID)

--- a/source/libs/editor/InspectorPanel.h
+++ b/source/libs/editor/InspectorPanel.h
@@ -7,11 +7,13 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <uuid.h>
 
 class ObjectManager;
 class AssetRegistry;
 class Component;
+class ComponentRegistry;
 class ComponentEditor;
 class GpuAssetCache;
 class EditorSelection;
@@ -28,7 +30,9 @@ public:
   using EditCallback = std::function<void(const uuids::uuid& objectUUID, const std::shared_ptr<Component>& component)>;
   using SceneEditCallback = std::function<void(const nlohmann::json& edit)>;
 
-  InspectorPanel(std::shared_ptr<ComponentEditor> componentEditor, std::shared_ptr<GpuAssetCache> assetCache);
+  InspectorPanel(std::shared_ptr<ComponentEditor> componentEditor,
+                 std::shared_ptr<ComponentRegistry> componentRegistry,
+                 std::shared_ptr<GpuAssetCache> assetCache);
 
   ~InspectorPanel();
 
@@ -58,6 +62,11 @@ public:
   void setRemoveAssetCallback(std::function<void(const uuids::uuid& assetUUID)> callback);
 
   void setAssetReferenceCountCallback(std::function<int(const uuids::uuid& assetUUID)> callback);
+
+  // Forwarded to the asset inspector's editable prefab body: a prefab body edit (re-register under the
+  // existing name to update the body in place, keeping the uuid; the server re-snapshots).
+  void setUpdatePrefabBodyCallback(std::function<void(const uuids::uuid& assetUUID, const std::string& name,
+                                                      const std::string& body)> callback);
 
   // objectManager may be null (no scene loaded yet): the window is still drawn (empty) so it stays
   // present/dockable instead of popping in and out. activeSceneUUID is the currently loaded scene, used

--- a/source/libs/editor/ObjectInspector.cpp
+++ b/source/libs/editor/ObjectInspector.cpp
@@ -108,6 +108,11 @@ void ObjectInspector::setEditable(const bool editable)
   m_editable = editable;
 }
 
+void ObjectInspector::setShowHighlightToggle(const bool show)
+{
+  m_showHighlightToggle = show;
+}
+
 void ObjectInspector::displayTypeChip(const std::shared_ptr<Object>& object) const
 {
   const char* typeLabel = labelForObject(object);
@@ -117,9 +122,12 @@ void ObjectInspector::displayTypeChip(const std::shared_ptr<Object>& object) con
 
 void ObjectInspector::display(const std::shared_ptr<Object>& object)
 {
-  gc::accentCheckbox("Highlight Object", &m_highlightObject);
+  if (m_showHighlightToggle)
+  {
+    gc::accentCheckbox("Highlight Object", &m_highlightObject);
 
-  ImGui::Separator();
+    ImGui::Separator();
+  }
 
   // Sync the name buffer when the selection changes. Also fold the shown object back to a closed
   // Add Component list, so a viewport pick (which writes the shared selection directly) matches the

--- a/source/libs/editor/ObjectInspector.h
+++ b/source/libs/editor/ObjectInspector.h
@@ -35,6 +35,11 @@ public:
 
   void setEditable(bool editable);
 
+  // When false, the "Highlight Object" checkbox at the top is omitted. The Highlight toggle only means
+  // something for a live scene object (it drives the viewport highlight); the AssetInspector reuses this
+  // inspector to edit a detached prefab body, where there is nothing to highlight.
+  void setShowHighlightToggle(bool show);
+
   // The right-aligned type chip in the panel header (icon pill), drawn on the current header row.
   void displayTypeChip(const std::shared_ptr<Object>& object) const;
 
@@ -59,6 +64,9 @@ private:
   std::optional<uuids::uuid> m_nameEditObjectUUID;
 
   bool m_highlightObject = true;
+
+  // Whether to draw the Highlight toggle (see setShowHighlightToggle).
+  bool m_showHighlightToggle = true;
 
   // Components whose deletion we've already sent (markedAsDeleted persists until the next snapshot
   // rebuilds the object), so we don't re-send the same removeComponent every frame.

--- a/source/libs/editor/TransientObject.cpp
+++ b/source/libs/editor/TransientObject.cpp
@@ -1,0 +1,85 @@
+#include "TransientObject.h"
+#include <objects/Object.h>
+#include <objects/ObjectManager.h>
+#include <nlohmann/json.hpp>
+#include <exception>
+#include <utility>
+
+TransientObject::TransientObject(std::shared_ptr<ComponentRegistry> componentRegistry)
+  : m_componentRegistry(std::move(componentRegistry))
+{}
+
+// Defined here (not defaulted in the header) so the unique_ptr<ObjectManager> sees the complete type.
+TransientObject::~TransientObject() = default;
+
+bool TransientObject::syncFromBody(const std::string& body)
+{
+  if (m_loadedBody.has_value() && m_loadedBody.value() == body)
+  {
+    return false;
+  }
+
+  rebuild(body);
+  return true;
+}
+
+void TransientObject::markSynced(const std::string& body)
+{
+  m_loadedBody = body;
+}
+
+ObjectManager* TransientObject::manager() const
+{
+  return m_manager.get();
+}
+
+const std::shared_ptr<Object>& TransientObject::object() const
+{
+  return m_object;
+}
+
+std::string TransientObject::serialize() const
+{
+  return m_object ? m_object->serialize().dump() : std::string{};
+}
+
+void TransientObject::rebuild(const std::string& body)
+{
+  // Remember the blob even if it fails to build, so a malformed/empty body isn't re-parsed every frame.
+  m_loadedBody = body;
+  m_manager.reset();
+  m_object.reset();
+
+  auto parsed = nlohmann::json::parse(body, nullptr, false);
+  if (parsed.is_discarded() || !parsed.is_object())
+  {
+    return;
+  }
+
+  try
+  {
+    // A private manager owns the object exactly as a scene's does — but is never handed to any scene,
+    // SceneManager, or replication path, so the object stays out of the simulation. Preserve the body's
+    // uuids (no reassignUUIDs) so the body is stable across edits.
+    m_manager = std::make_unique<ObjectManager>(m_componentRegistry);
+
+    auto object = std::make_shared<Object>(parsed, m_manager.get());
+    m_manager->addObject(object);
+
+    // Object's ctor loads only its own components/scripts; children are separate objects (mirrors
+    // ObjectManager::instantiateUnder), needed here so the whole subtree survives the re-serialize.
+    if (parsed.contains("children"))
+    {
+      object->loadChildren(parsed.at("children"));
+    }
+
+    m_object = std::move(object);
+  }
+  catch (const std::exception&)
+  {
+    // A malformed body (unknown component type, missing uuid/name) — leave the object null; the inspector
+    // shows its "unavailable" fallback.
+    m_manager.reset();
+    m_object.reset();
+  }
+}

--- a/source/libs/editor/TransientObject.h
+++ b/source/libs/editor/TransientObject.h
@@ -1,0 +1,63 @@
+#ifndef TRANSIENTOBJECT_H
+#define TRANSIENTOBJECT_H
+
+#include <memory>
+#include <optional>
+#include <string>
+
+class ComponentRegistry;
+class Object;
+class ObjectManager;
+
+// A detached Object deserialized from a serialized-object blob (a prefab's AssetRecord::body), living in a
+// private scratch ObjectManager that is never wired to a scene, the SceneManager, or replication. It exists
+// solely so the editor's component editors can operate on prefab contents out-of-scene (see ROADMAP Phase 4
+// / B2). uuids are preserved on load (not reassigned like instantiation), so the body stays stable across
+// edits; re-serialize after an edit to produce the updated body to send.
+//
+// The private manager is what lets the whole existing deserialize path (Object + children) and
+// replication::applySceneEdit be reused verbatim — the "detached" object is detached from any *scene*, not
+// from an ObjectManager, which Object fundamentally needs to deserialize and to apply structural edits.
+class TransientObject {
+public:
+  explicit TransientObject(std::shared_ptr<ComponentRegistry> componentRegistry);
+
+  ~TransientObject();
+
+  // (Re)build the detached object from `body` when it differs from the blob currently loaded — an external
+  // change (a fresh snapshot, or a different prefab selected). Returns true when a rebuild happened (any
+  // pointers the caller cached into the old object are now stale). A malformed/empty body clears the object
+  // (object() becomes null) and is remembered so it isn't re-parsed every frame. Safe to call every frame.
+  bool syncFromBody(const std::string& body);
+
+  // Adopt `body` as the currently-loaded blob WITHOUT rebuilding — call after applying a local edit whose
+  // serialized body you already hold, so the next syncFromBody(recordBody) with that same string is a no-op
+  // instead of a rebuild that would discard the live (edited) object.
+  void markSynced(const std::string& body);
+
+  // The scratch manager backing the object — replication::applySceneEdit targets this so structural edits
+  // (add/remove component, rename, add script) apply to the detached object in place. Null until a
+  // successful sync.
+  [[nodiscard]] ObjectManager* manager() const;
+
+  // The detached root object, or null when the last sync had no usable body.
+  [[nodiscard]] const std::shared_ptr<Object>& object() const;
+
+  // Serialize the current object back to a body blob (Object::serialize().dump()), or an empty string when
+  // there is no object. Feed the result to markSynced after sending it.
+  [[nodiscard]] std::string serialize() const;
+
+private:
+  void rebuild(const std::string& body);
+
+  std::shared_ptr<ComponentRegistry> m_componentRegistry;
+
+  std::unique_ptr<ObjectManager> m_manager;
+  std::shared_ptr<Object> m_object;
+
+  // The blob currently reflected by m_object (whether it built successfully or not), used to skip redundant
+  // rebuilds. nullopt until the first sync.
+  std::optional<std::string> m_loadedBody;
+};
+
+#endif //TRANSIENTOBJECT_H


### PR DESCRIPTION
This pull request introduces editable prefab body support in the editor, allowing users to edit prefab contents directly in the Inspector panel. Prefab bodies are now deserialized into detached objects and edited using the same component editors as scene objects, with edits coalesced and sent efficiently to avoid unnecessary network traffic. The implementation includes new callbacks, state tracking, and integration with the EditorApp and InspectorPanel.

**Prefab Body Editing and Inspector Integration:**

* The `AssetInspector` now supports editing prefab bodies: prefab contents are deserialized into a detached `TransientObject` and edited with a reused `ObjectInspector`. Edits are applied locally for instant feedback and coalesced so that only one update is sent when editing is complete. [[1]](diffhunk://#diff-609c9a7a2577344e18c04305b8044f3efd81533d02c4ae6cfd77127e934a54c2L21-R49) [[2]](diffhunk://#diff-609c9a7a2577344e18c04305b8044f3efd81533d02c4ae6cfd77127e934a54c2L386-R483) [[3]](diffhunk://#diff-e8f36a86258ac931eed63ae26f162fa6e3cd1a3c948b3936cf56ea6f6d81e9b8R37-R46) [[4]](diffhunk://#diff-e8f36a86258ac931eed63ae26f162fa6e3cd1a3c948b3936cf56ea6f6d81e9b8R75-R103)
* Added a new `UpdatePrefabBodyCallback` and related setter to `AssetInspector`, allowing the editor to re-register the prefab under its existing name and UUID after edits, mirroring the "Save as Prefab" workflow. [[1]](diffhunk://#diff-e8f36a86258ac931eed63ae26f162fa6e3cd1a3c948b3936cf56ea6f6d81e9b8R37-R46) [[2]](diffhunk://#diff-e8f36a86258ac931eed63ae26f162fa6e3cd1a3c948b3936cf56ea6f6d81e9b8L42-R63) [[3]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L254-R267) [[4]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4R276)
* The Inspector UI now disables prefab editing in read-only mode and ensures proper registry context for script asset resolution. [[1]](diffhunk://#diff-e8f36a86258ac931eed63ae26f162fa6e3cd1a3c948b3936cf56ea6f6d81e9b8L42-R63) [[2]](diffhunk://#diff-609c9a7a2577344e18c04305b8044f3efd81533d02c4ae6cfd77127e934a54c2R71-R80) [[3]](diffhunk://#diff-609c9a7a2577344e18c04305b8044f3efd81533d02c4ae6cfd77127e934a54c2R95)
* The prefab body display logic has been replaced: instead of a read-only tree, the body is now editable and uses the same component editors as live objects, with structural edits applied after display and value edits marked dirty. [[1]](diffhunk://#diff-609c9a7a2577344e18c04305b8044f3efd81533d02c4ae6cfd77127e934a54c2L86-R123) [[2]](diffhunk://#diff-609c9a7a2577344e18c04305b8044f3efd81533d02c4ae6cfd77127e934a54c2L153-R192)
* Documentation and comments have been updated throughout (`AGENTS.md`) to describe the new editable prefab workflow and its implementation details. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L34-R34) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L126-R138)