### PR TITLE
Refine engine documentation and clean up comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,13 @@ is true — the same signal `vke` gates its free-fly camera on. The keyboard sti
   Splitting a new component means: fields → `data`, physics → `sim`, rendering → `render`, bindings →
   `scripting`, inspector widget → `editor`. Register it in `registerDataComponents()`.
 - **Source-list discipline:** every new file goes in its library's `CMakeLists.txt` source list.
+- **Comments:** write them sparingly. Prefer self-documenting code (clear names, small functions) over a
+  comment; if code needs a comment to be understood, first ask whether it can be made clearer instead.
+  Comment only what the code cannot say for itself -- the *why* behind a non-obvious algorithm, design
+  decision, workaround, or caveat -- never a restatement of *what* the line does. Keep them short (1-2
+  lines). Do not narrate implementation history ("was X", "moved from Y", "Phase N", "temporary") or
+  point at external plans/roadmaps -- describe the code as it is now. **Comments are ASCII-only:** no
+  em dashes, arrows, or other Unicode -- use `-`, `->`, `<->`.
 
 ## Applications
 

--- a/source/apps/client/ClientApp.cpp
+++ b/source/apps/client/ClientApp.cpp
@@ -173,7 +173,7 @@ void ClientApp::connectToServer()
 
 void ClientApp::createRenderer()
 {
-  // Ported from ECS3D::initRenderer. The client is a lightweight view, so no custom ImGui style.
+  // The client is a lightweight view, so no custom ImGui style.
   const vke::EngineConfig engineConfig {
     .window {
       .width = 1280,
@@ -199,7 +199,7 @@ void ClientApp::variableUpdate() const
     m_renderSystem->variableUpdate(*scene->getObjectManager(), *m_assetCache);
 
     // Render through this client's own player camera (the object with our PlayerController slot + a
-    // Camera); nullopt falls back to the scene's first active camera / free-fly (Phase 4.4).
+    // Camera); nullopt falls back to the scene's first active camera / free-fly.
     m_renderSystem->updateCamera(*scene->getObjectManager(), *m_assetCache, resolvePlayerCamera());
   }
 

--- a/source/apps/client/ClientApp.h
+++ b/source/apps/client/ClientApp.h
@@ -71,7 +71,7 @@ private:
   bool m_inputSent = false;
 
   // A per-session random tag sent in join; the server echoes it back in a playerSlot message so this
-  // client can pick out its own slot assignment from the broadcast (Phase 4.4).
+  // client can pick out its own slot assignment from the broadcast.
   uint64_t m_joinNonce = 0;
   // The player slot the server bound this client to (-1 until the playerSlot message arrives). Drives
   // which object's Camera the client renders through. mutable: set from the const message-apply path.

--- a/source/apps/client/ClientApp.h
+++ b/source/apps/client/ClientApp.h
@@ -100,7 +100,7 @@ private:
   void handlePlayerSlot(const net::Message& message) const;
 
   // The object this client should render through: the one carrying a PlayerController for this client's
-  // player slot and a Camera. nullopt when the slot is still unknown or no such camera exists — the
+  // player slot and a Camera. nullopt when the slot is still unknown or no such camera exists - the
   // caller then falls back to the scene's first active camera / free-fly (RenderSystem::updateCamera).
   [[nodiscard]] std::optional<uuids::uuid> resolvePlayerCamera() const;
 };

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -230,7 +230,7 @@ EditorApp::EditorApp(LaunchOptions options)
   m_selection = std::make_shared<EditorSelection>();
 
   // The object tree owns the hierarchy + structural tree edits + "Save as Prefab"; the Inspector owns
-  // the selected item's body (object component editing today). Both read/write the one selection slot.
+  // the selected item's body. Both read/write the one selection slot.
   m_objectGUIManager = std::make_shared<ObjectGUIManager>();
   m_objectGUIManager->setSelection(m_selection);
   m_objectGUIManager->setAddAssetCallback(addAsset);
@@ -508,7 +508,7 @@ void EditorApp::sendSceneControl(const net::SceneControlOp op) const
 
 void EditorApp::createRenderer()
 {
-  // Ported from ECS3D::initRenderer. Unlike the client, the editor keeps the custom ImGui style.
+  // Unlike the client, the editor keeps the custom ImGui style.
   const vke::EngineConfig engineConfig {
     .window {
       .width = 1280,
@@ -1028,9 +1028,8 @@ void EditorApp::setupImGuiStyle()
 {
   ImGui::SetCurrentContext(vke::ImGuiInstance::getImGuiContext());
 
-  // Redesign prototype: drive the global style from the shared design tokens (see EditorTheme.h /
-  // "ECS3D Editor.dc" mockup). The legacy "Future Dark" block below is retained (disabled) for
-  // reference while the redesign is in progress.
+  // Drive the global style from the shared design tokens (see EditorTheme.h / "ECS3D Editor.dc"
+  // mockup). The disabled "Future Dark" block below is kept for reference.
   theme::applyStyle();
 
 #if 0

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -68,10 +68,9 @@ namespace {
     return label;
   }
 
-  // Whether any of an object's components serialize the asset uuid (models/textures store it as a string
-  // field — see ModelRenderer::serialize). Searching the serialized form keeps this generic: no layer here
-  // names a concrete component type. Scripts reference assets by class name and prefab instances are
-  // detached copies, so only model/texture uuids ever match — exactly the references that would dangle.
+  // Whether any of the object's components mention the asset uuid in their serialized form. Searching the
+  // serialized form keeps this generic (no component type named here); only model/texture references —
+  // the ones that would dangle — ever match.
   bool objectReferencesAsset(const std::shared_ptr<Object>& object, const std::string& uuidString)
   {
     for (const auto& [type, component] : object->getComponents())
@@ -141,17 +140,15 @@ EditorApp::EditorApp(LaunchOptions options)
   m_componentEditor = std::make_shared<ComponentEditor>();
   registerEditors();
 
-  // Registering a new asset: apply it locally for instant feedback, then on the authoritative server
-  // (which re-snapshots to keep everyone in sync). Shared by the asset browser's import/create and the
-  // object tree's "Save as Prefab".
+  // Register a new asset: apply locally for instant feedback, then on the server (which re-snapshots).
+  // Shared by the asset browser's import/create and the object tree's "Save as Prefab".
   const auto addAsset = [this](const nlohmann::json& asset) {
     replication::applyAddAsset(*m_assetRegistry, *m_sceneManager, m_componentRegistry, asset);
 
     m_netClient->send(replication::packAddAsset(asset));
   };
 
-  // Renaming an asset (display-name override only): apply locally for instant feedback, then on the
-  // authoritative server (which re-snapshots). Same local-apply-then-send shape as addAsset.
+  // Rename an asset (display-name override only). Same local-apply-then-send shape as addAsset.
   const auto renameAsset = [this](const uuids::uuid& assetUUID, const std::string& displayName) {
     const auto op = replication::buildRenameAsset(assetUUID, displayName);
     replication::applyRenameAsset(*m_assetRegistry, op);
@@ -159,8 +156,8 @@ EditorApp::EditorApp(LaunchOptions options)
     m_netClient->send(replication::packRenameAsset(op));
   };
 
-  // Deleting an asset: same local-apply-then-send shape. Deletion always succeeds; any references dangle
-  // (lookups null-tolerate a missing uuid), so nothing else needs to change here.
+  // Delete an asset: same local-apply-then-send shape. Deletion always succeeds; references dangle
+  // (lookups null-tolerate a missing uuid).
   const auto removeAsset = [this](const uuids::uuid& assetUUID) {
     const auto op = replication::buildRemoveAsset(assetUUID);
     replication::applyRemoveAsset(*m_assetRegistry, op);
@@ -207,8 +204,7 @@ EditorApp::EditorApp(LaunchOptions options)
     return count;
   };
 
-  // A component widget changed: send the component's new state to the authoritative server as an edit
-  // command. Only the Inspector fires this (component value edits).
+  // A component value edit: send the component's new state to the server. Only the Inspector fires this.
   const auto editComponent = [this](const uuids::uuid& objectUUID, const std::shared_ptr<Component>& component) {
     const auto message = replication::buildComponentEdit(objectUUID, component);
     m_netClient->send(message);
@@ -236,9 +232,8 @@ EditorApp::EditorApp(LaunchOptions options)
   m_objectGUIManager->setAddAssetCallback(addAsset);
   m_objectGUIManager->setSceneEditCallback(sceneEdit);
 
-  // Switch the active scene: apply locally for instant feedback (the editor has every scene), then tell
-  // the authoritative server, which re-snapshots to keep everyone in sync. Shared by the asset browser's
-  // scene double-click and the Inspector's "Load Scene" button.
+  // Switch the active scene: apply locally for instant feedback, then tell the server (which re-snapshots).
+  // Shared by the asset browser's scene double-click and the Inspector's "Load Scene" button.
   const auto loadScene = [this](const uuids::uuid& sceneUUID) {
     if (const auto scene = m_sceneManager->getScene(sceneUUID))
     {
@@ -251,9 +246,8 @@ EditorApp::EditorApp(LaunchOptions options)
     m_netClient->send(message);
   };
 
-  // A prefab body edit from the inspector: re-register the prefab under its existing name, which updates the
-  // body in place and keeps the uuid (the same path "Save as Prefab" over an existing name takes). Same
-  // local-apply-then-send addAsset shape as everything else.
+  // A prefab body edit: re-register under the existing name, updating the body in place and keeping the
+  // uuid — the same path "Save as Prefab" over an existing name takes, via the same addAsset shape.
   const auto updatePrefabBody = [addAsset](const uuids::uuid& assetUUID, const std::string& name,
                                            const std::string& body) {
     addAsset({
@@ -282,9 +276,8 @@ EditorApp::EditorApp(LaunchOptions options)
 
   m_saveUI = std::make_shared<SaveUI>(m_projectSerializer.get(), m_renderer);
   m_saveUI->setLoadProjectCallback([this] {
-    // Open/New: the server owns the running sim, so send it the project; it reloads and re-snapshots.
-    // SaveUI has already applied the project to our managers, so pack their current state — the same
-    // packed shape as a snapshot, which the server unpacks with the same ProjectPacker.
+    // Open/New: the server owns the running sim, so send it the packed project (SaveUI already applied it
+    // to our managers); it reloads and re-snapshots.
     net::Message message(net::MessageType::loadProject);
     m_projectPacker->pack(message);
 
@@ -319,8 +312,7 @@ void EditorApp::connectToServer()
     m_authToken = uuids::to_string(uuids::uuid_random_generator{ rng }());
 
     m_serverProcess = std::make_unique<net::ServerProcess>();
-    // --edit grants the editor capability, --token is the secret the editor must present, and
-    // --ephemeral makes the server exit when its last connection drops so it can't outlive the editor.
+    // --ephemeral makes the server exit when its last connection drops, so it can't outlive the editor.
     const std::string arguments = "--edit --ephemeral --token " + m_authToken;
     if (!m_serverProcess->launch("ECS3DServer", arguments))
     {
@@ -399,8 +391,8 @@ void EditorApp::handlePicking()
   const auto window = m_renderer->getWindow();
   const bool pressed = window->buttonIsPressed(GLFW_MOUSE_BUTTON_LEFT);
 
-  // Select on a fresh Ctrl+Left-click while the cursor is over the 3D viewport. isSelected() is the
-  // renderer's pick feedback from last frame's render.
+  // Select on a fresh Ctrl+Left-click over the viewport. isSelected() is the renderer's pick result
+  // from last frame.
   const auto mousePicker = m_renderer->getRenderingManager()->getRenderer3D()->getMousePicker();
   if (!m_mouseWasPressed && pressed && window->keyIsPressed(GLFW_KEY_LEFT_CONTROL) && mousePicker->canMousePick())
   {
@@ -414,8 +406,7 @@ void EditorApp::handlePicking()
       }
     }
 
-    // Picks the clicked object, or clears the selection when empty space was clicked. Writes the
-    // shared selection directly (the object tree/inspector read the same instance).
+    // Written directly to the shared selection the object tree/inspector read.
     if (picked.has_value())
     {
       m_selection->selectObject(picked.value());
@@ -433,9 +424,8 @@ void EditorApp::sendInput()
 {
   const auto& io = ImGui::GetIO();
 
-  // Don't let editor UI interaction drive the game: when ImGui wants the keyboard, report no keys.
-  // focused stays true (an unfocused window already reports no keys), so this view never disables
-  // another connected view's input.
+  // Don't let editor UI typing drive the game: when ImGui wants the keyboard, report no keys. focused
+  // stays true so this view never disables another connected view's input.
   input::InputSnapshot snapshot = input::capture(*m_renderer);
 
   if (io.WantCaptureKeyboard)
@@ -443,12 +433,10 @@ void EditorApp::sendInput()
     snapshot.keys.clear();
   }
 
-  // The mouse can't be gated on io.WantCaptureMouse: the 3D viewport is itself an ImGui window in the
-  // editor's dockspace, so that flag is set whenever the cursor is over it — which would swallow the
-  // right-drag mouse-look a script reads. Forward the mouse only while looking through a scene camera
-  // (in free-fly the right-drag belongs to the editor's own camera, so sending it too would turn the
-  // player at the same time) and while the scene view is focused, which is the signal vke's free-fly
-  // camera gates on and goes false as soon as a panel is clicked.
+  // The mouse can't be gated on io.WantCaptureMouse: the viewport is itself an ImGui window, so that
+  // flag is set whenever the cursor is over it, which would swallow the right-drag mouse-look a script
+  // reads. Forward the mouse only while looking through a scene camera (in free-fly the right-drag is
+  // the editor's own camera) and while the scene view is focused.
   const bool mouseDrivesGame = m_viewCameraObject.has_value()
                             && m_renderer->getRenderingManager()->isSceneFocused();
 
@@ -664,8 +652,8 @@ void EditorApp::updateGui()
     return;
   }
 
-  // Propagate the server's editability to the panels so they disable their mutating affordances (and
-  // show a read-only cue) when connected to a non-edit server, rather than appearing broken.
+  // Propagate the server's editability so the panels disable their mutating affordances (and show a
+  // read-only cue) on a non-edit server.
   m_objectGUIManager->setEditable(m_serverEditable);
   m_inspectorPanel->setEditable(m_serverEditable);
   m_assetBrowser->setEditable(m_serverEditable);
@@ -701,9 +689,8 @@ void EditorApp::displayMenuBar() const
 
     if (ImGui::BeginMenu("File"))
     {
-      // Save serializes the replicated project to disk; New/Open send the project to the server (which
-      // reloads + re-snapshots), since the server owns the scene. New/Open are mutations, so they're
-      // disabled on a read-only server; Save (local serialization of what's on screen) stays available.
+      // Save serializes the replicated project to disk; New/Open send it to the server (which reloads +
+      // re-snapshots). New/Open are mutations, disabled on a read-only server; Save stays available.
       ImGui::BeginDisabled(!m_serverEditable);
       if (ImGui::MenuItem("New"))
       {
@@ -1028,98 +1015,5 @@ void EditorApp::setupImGuiStyle()
 {
   ImGui::SetCurrentContext(vke::ImGuiInstance::getImGuiContext());
 
-  // Drive the global style from the shared design tokens (see EditorTheme.h / "ECS3D Editor.dc"
-  // mockup). The disabled "Future Dark" block below is kept for reference.
   theme::applyStyle();
-
-#if 0
-  // Future Dark style by rewrking from ImThemes
-  ImGuiStyle& style = ImGui::GetStyle();
-
-  style.Alpha = 1.0f;
-  style.DisabledAlpha = 1.0f;
-  style.WindowPadding = ImVec2(12.0f, 12.0f);
-  style.WindowRounding = 0.0f;
-  style.WindowBorderSize = 0.0f;
-  style.WindowMinSize = ImVec2(20.0f, 20.0f);
-  style.WindowTitleAlign = ImVec2(0.5f, 0.5f);
-  style.WindowMenuButtonPosition = ImGuiDir_None;
-  style.ChildRounding = 0.0f;
-  style.ChildBorderSize = 1.0f;
-  style.PopupRounding = 0.0f;
-  style.PopupBorderSize = 1.0f;
-  style.FramePadding = ImVec2(6.0f, 6.0f);
-  style.FrameRounding = 0.0f;
-  style.FrameBorderSize = 0.0f;
-  style.ItemSpacing = ImVec2(12.0f, 6.0f);
-  style.ItemInnerSpacing = ImVec2(6.0f, 3.0f);
-  style.CellPadding = ImVec2(12.0f, 6.0f);
-  style.IndentSpacing = 20.0f;
-  style.ColumnsMinSpacing = 6.0f;
-  style.ScrollbarSize = 12.0f;
-  style.ScrollbarRounding = 0.0f;
-  style.GrabMinSize = 12.0f;
-  style.GrabRounding = 0.0f;
-  style.TabRounding = 0.0f;
-  style.TabBorderSize = 0.0f;
-  style.TabCloseButtonMinWidthSelected = 0.0f;
-  style.TabCloseButtonMinWidthUnselected = 0.0f;
-  style.ColorButtonPosition = ImGuiDir_Right;
-  style.ButtonTextAlign = ImVec2(0.5f, 0.5f);
-  style.SelectableTextAlign = ImVec2(0.0f, 0.0f);
-
-  style.Colors[ImGuiCol_Text] = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
-  style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.2745098173618317f, 0.3176470696926117f, 0.4509803950786591f, 1.0f);
-  style.Colors[ImGuiCol_WindowBg] = ImVec4(0.0784313753247261f, 0.08627451211214066f, 0.1019607856869698f, 1.0f);
-  style.Colors[ImGuiCol_ChildBg] = ImVec4(0.0784313753247261f, 0.08627451211214066f, 0.1019607856869698f, 1.0f);
-  style.Colors[ImGuiCol_PopupBg] = ImVec4(0.0784313753247261f, 0.08627451211214066f, 0.1019607856869698f, 1.0f);
-  style.Colors[ImGuiCol_Border] = ImVec4(0.1568627506494522f, 0.168627455830574f, 0.1921568661928177f, 1.0f);
-  style.Colors[ImGuiCol_BorderShadow] = ImVec4(0.0784313753247261f, 0.08627451211214066f, 0.1019607856869698f, 1.0f);
-  style.Colors[ImGuiCol_FrameBg] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.1568627506494522f, 0.168627455830574f, 0.1921568661928177f, 1.0f);
-  style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.2352941185235977f, 0.2156862765550613f, 0.5960784554481506f, 1.0f);
-  style.Colors[ImGuiCol_TitleBg] = ImVec4(0.0470588244497776f, 0.05490196123719215f, 0.07058823853731155f, 1.0f);
-  style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.0470588244497776f, 0.05490196123719215f, 0.07058823853731155f, 1.0f);
-  style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.0784313753247261f, 0.08627451211214066f, 0.1019607856869698f, 1.0f);
-  style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.09803921729326248f, 0.105882354080677f, 0.1215686276555061f, 1.0f);
-  style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.0470588244497776f, 0.05490196123719215f, 0.07058823853731155f, 1.0f);
-  style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.1568627506494522f, 0.168627455830574f, 0.1921568661928177f, 1.0f);
-  style.Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_CheckMark] = ImVec4(0.4980392158031464f, 0.5137255191802979f, 1.0f, 1.0f);
-  style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.4980392158031464f, 0.5137255191802979f, 1.0f, 1.0f);
-  style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.5372549295425415f, 0.5529412031173706f, 1.0f, 1.0f);
-  style.Colors[ImGuiCol_Button] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.196078434586525f, 0.1764705926179886f, 0.5450980663299561f, 1.0f);
-  style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.2352941185235977f, 0.2156862765550613f, 0.5960784554481506f, 1.0f);
-  style.Colors[ImGuiCol_Header] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.196078434586525f, 0.1764705926179886f, 0.5450980663299561f, 1.0f);
-  style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.2352941185235977f, 0.2156862765550613f, 0.5960784554481506f, 1.0f);
-  style.Colors[ImGuiCol_Separator] = ImVec4(0.1568627506494522f, 0.1843137294054031f, 0.250980406999588f, 1.0f);
-  style.Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.1568627506494522f, 0.1843137294054031f, 0.250980406999588f, 1.0f);
-  style.Colors[ImGuiCol_SeparatorActive] = ImVec4(0.1568627506494522f, 0.1843137294054031f, 0.250980406999588f, 1.0f);
-  style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.196078434586525f, 0.1764705926179886f, 0.5450980663299561f, 1.0f);
-  style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.2352941185235977f, 0.2156862765550613f, 0.5960784554481506f, 1.0f);
-  style.Colors[ImGuiCol_Tab] = ImVec4(0.0470588244497776f, 0.05490196123719215f, 0.07058823853731155f, 1.0f);
-  style.Colors[ImGuiCol_TabHovered] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_TabActive] = ImVec4(0.09803921729326248f, 0.105882354080677f, 0.1215686276555061f, 1.0f);
-  style.Colors[ImGuiCol_TabUnfocused] = ImVec4(0.0470588244497776f, 0.05490196123719215f, 0.07058823853731155f, 1.0f);
-  style.Colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.0784313753247261f, 0.08627451211214066f, 0.1019607856869698f, 1.0f);
-  style.Colors[ImGuiCol_PlotLines] = ImVec4(0.5215686559677124f, 0.6000000238418579f, 0.7019608020782471f, 1.0f);
-  style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.03921568766236305f, 0.9803921580314636f, 0.9803921580314636f, 1.0f);
-  style.Colors[ImGuiCol_PlotHistogram] = ImVec4(1.0f, 0.2901960909366608f, 0.5960784554481506f, 1.0f);
-  style.Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.9960784316062927f, 0.4745098054409027f, 0.6980392336845398f, 1.0f);
-  style.Colors[ImGuiCol_TableHeaderBg] = ImVec4(0.0470588244497776f, 0.05490196123719215f, 0.07058823853731155f, 1.0f);
-  style.Colors[ImGuiCol_TableBorderStrong] = ImVec4(0.0470588244497776f, 0.05490196123719215f, 0.07058823853731155f, 1.0f);
-  style.Colors[ImGuiCol_TableBorderLight] = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
-  style.Colors[ImGuiCol_TableRowBg] = ImVec4(0.1176470592617989f, 0.1333333402872086f, 0.1490196138620377f, 1.0f);
-  style.Colors[ImGuiCol_TableRowBgAlt] = ImVec4(0.09803921729326248f, 0.105882354080677f, 0.1215686276555061f, 1.0f);
-  style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.2352941185235977f, 0.2156862765550613f, 0.5960784554481506f, 1.0f);
-  style.Colors[ImGuiCol_DragDropTarget] = ImVec4(0.4980392158031464f, 0.5137255191802979f, 1.0f, 1.0f);
-  style.Colors[ImGuiCol_NavHighlight] = ImVec4(0.4980392158031464f, 0.5137255191802979f, 1.0f, 1.0f);
-  style.Colors[ImGuiCol_NavWindowingHighlight] = ImVec4(0.4980392158031464f, 0.5137255191802979f, 1.0f, 1.0f);
-  style.Colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.196078434586525f, 0.1764705926179886f, 0.5450980663299561f, 0.501960813999176f);
-  style.Colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.196078434586525f, 0.1764705926179886f, 0.5450980663299561f, 0.501960813999176f);
-#endif
 }

--- a/source/apps/editor/EditorApp.cpp
+++ b/source/apps/editor/EditorApp.cpp
@@ -69,8 +69,8 @@ namespace {
   }
 
   // Whether any of the object's components mention the asset uuid in their serialized form. Searching the
-  // serialized form keeps this generic (no component type named here); only model/texture references —
-  // the ones that would dangle — ever match.
+  // serialized form keeps this generic (no component type named here); only model/texture references -
+  // the ones that would dangle - ever match.
   bool objectReferencesAsset(const std::shared_ptr<Object>& object, const std::string& uuidString)
   {
     for (const auto& [type, component] : object->getComponents())
@@ -166,7 +166,7 @@ EditorApp::EditorApp(LaunchOptions options)
   };
 
   // How many objects reference an asset by uuid, for the delete-confirmation modal's warning. Scans the
-  // replicated scenes' objects and every prefab body — the two places an object tree lives editor-side.
+  // replicated scenes' objects and every prefab body - the two places an object tree lives editor-side.
   const auto countAssetReferences = [this](const uuids::uuid& assetUUID) {
     const auto uuidString = uuids::to_string(assetUUID);
     int count = 0;
@@ -247,7 +247,7 @@ EditorApp::EditorApp(LaunchOptions options)
   };
 
   // A prefab body edit: re-register under the existing name, updating the body in place and keeping the
-  // uuid — the same path "Save as Prefab" over an existing name takes, via the same addAsset shape.
+  // uuid - the same path "Save as Prefab" over an existing name takes, via the same addAsset shape.
   const auto updatePrefabBody = [addAsset](const uuids::uuid& assetUUID, const std::string& name,
                                            const std::string& body) {
     addAsset({

--- a/source/apps/editor/EditorApp.h
+++ b/source/apps/editor/EditorApp.h
@@ -83,7 +83,7 @@ private:
   std::shared_ptr<RenderSystem> m_renderSystem;
 
   // The editor-wide selection slot (object vs. asset vs. nothing), shared into the panels that read or
-  // write it — the object tree, inspector, and asset browser. handlePicking writes it directly from
+  // write it - the object tree, inspector, and asset browser. handlePicking writes it directly from
   // viewport mouse-picking.
   std::shared_ptr<EditorSelection> m_selection;
 

--- a/source/apps/editor/EditorApp.h
+++ b/source/apps/editor/EditorApp.h
@@ -83,8 +83,8 @@ private:
   std::shared_ptr<RenderSystem> m_renderSystem;
 
   // The editor-wide selection slot (object vs. asset vs. nothing), shared into the panels that read or
-  // write it — the object tree/inspector today, the asset browser in a later phase. handlePicking
-  // writes it directly from viewport mouse-picking.
+  // write it — the object tree, inspector, and asset browser. handlePicking writes it directly from
+  // viewport mouse-picking.
   std::shared_ptr<EditorSelection> m_selection;
 
   std::shared_ptr<ComponentEditor> m_componentEditor;

--- a/source/apps/launcher/source/App.axaml.cs
+++ b/source/apps/launcher/source/App.axaml.cs
@@ -21,7 +21,7 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // Wire the view to its view model explicitly — no ViewLocator needed
+            // Wire the view to its view model explicitly - no ViewLocator needed
             // while there is a single window.
             desktop.MainWindow = new MainWindow
             {

--- a/source/apps/launcher/source/Program.cs
+++ b/source/apps/launcher/source/Program.cs
@@ -5,7 +5,7 @@ namespace ECS3DLauncher;
 
 internal static class Program
 {
-    // Avalonia entry point. Keep this minimal — no app logic lives here.
+    // Avalonia entry point. Keep this minimal - no app logic lives here.
     [STAThread]
     public static void Main(string[] args) => BuildAvaloniaApp()
         .StartWithClassicDesktopLifetime(args);

--- a/source/apps/launcher/source/Shared/Converters/IconKeyConverter.cs
+++ b/source/apps/launcher/source/Shared/Converters/IconKeyConverter.cs
@@ -15,7 +15,7 @@ public sealed class IconKeyConverter : IValueConverter
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         // Use TryGetResource (not Resources.TryGetValue) so lookup traverses
-        // merged dictionaries and theme scopes — the icon geometries live in a
+        // merged dictionaries and theme scopes - the icon geometries live in a
         // merged ResourceInclude.
         if (value is string key &&
             Application.Current!.TryGetResource(key, null, out var res) &&

--- a/source/apps/launcher/source/Shared/DesignData.cs
+++ b/source/apps/launcher/source/Shared/DesignData.cs
@@ -6,7 +6,7 @@ namespace ECS3DLauncher.Shared;
 
 // Design-time view models. Referenced via d:DataContext so the Rider/Avalonia
 // previewer renders real content when a view is opened on its own, with no
-// runtime DataContext. Stripped from the app at runtime — design-only.
+// runtime DataContext. Stripped from the app at runtime - design-only.
 public static class DesignData
 {
     public static MainWindowViewModel MainWindow { get; } = new();

--- a/source/apps/launcher/source/Shell/MainWindow.axaml.cs
+++ b/source/apps/launcher/source/Shell/MainWindow.axaml.cs
@@ -32,7 +32,7 @@ public partial class MainWindow : Window
 
     private void OnGlobalPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        // Ignore presses inside a TextBox — those should keep (or take) focus.
+        // Ignore presses inside a TextBox - those should keep (or take) focus.
         if (e.Source is Visual v && v.FindAncestorOfType<TextBox>(includeSelf: true) is not null)
             return;
 

--- a/source/apps/launcher/source/Tabs/Learn/LearnViewModel.cs
+++ b/source/apps/launcher/source/Tabs/Learn/LearnViewModel.cs
@@ -1,4 +1,4 @@
 namespace ECS3DLauncher.Tabs.Learn;
 
-// Placeholder tab — no state yet; exists so the shell can template it to a view.
+// Placeholder tab - no state yet; exists so the shell can template it to a view.
 public sealed class LearnViewModel;

--- a/source/apps/launcher/source/Tabs/Samples/SamplesViewModel.cs
+++ b/source/apps/launcher/source/Tabs/Samples/SamplesViewModel.cs
@@ -1,4 +1,4 @@
 namespace ECS3DLauncher.Tabs.Samples;
 
-// Placeholder tab — no state yet; exists so the shell can template it to a view.
+// Placeholder tab - no state yet; exists so the shell can template it to a view.
 public sealed class SamplesViewModel;

--- a/source/apps/launcher/source/Tabs/Settings/SettingsViewModel.cs
+++ b/source/apps/launcher/source/Tabs/Settings/SettingsViewModel.cs
@@ -1,4 +1,4 @@
 namespace ECS3DLauncher.Tabs.Settings;
 
-// Placeholder tab — no state yet; exists so the shell can template it to a view.
+// Placeholder tab - no state yet; exists so the shell can template it to a view.
 public sealed class SettingsViewModel;

--- a/source/apps/server/DefaultProject.cpp
+++ b/source/apps/server/DefaultProject.cpp
@@ -328,7 +328,7 @@ json buildScene2()
   });
 }
 
-// Procedurally-generated tower of random spheres/blocks (was setup test loadScene3).
+// Procedurally-generated tower of random spheres/blocks.
 json buildScene3()
 {
   constexpr int gridSize = 6;
@@ -379,7 +379,7 @@ json buildScene3()
   return objects;
 }
 
-// Procedurally-generated grid of falling spheres (was the fallingBalls test).
+// Procedurally-generated grid of falling spheres.
 json buildFallingBalls()
 {
   constexpr int gridSize = 5;

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -44,7 +44,7 @@ ServerApp::ServerApp(LaunchOptions options)
   m_netServer = std::make_shared<net::NetServer>(m_host);
 
   // Scene queries live in sim, which scripting can't link; inject them into BindingContext so the World
-  // raycast/overlapSphere bindings can call them (the decided function-pointer injection for Phase 2.5).
+  // raycast/overlapSphere bindings can call them.
   BindingContext::setRaycast(&SceneQueries::raycast);
   BindingContext::setOverlapSphere(&SceneQueries::overlapSphere);
 
@@ -315,7 +315,7 @@ void ServerApp::handleJoin(const net::Message& message, const int32_t senderId)
   const int32_t slot = assignPlayerSlot(senderId);
 
   // If the joining client tagged its request with a nonce (players do; the editor sends none), tell it
-  // which player slot it was bound to so it can render through that player's camera (Phase 4.4). Broadcast
+  // which player slot it was bound to so it can render through that player's camera. Broadcast
   // + nonce correlation avoids a per-connection send path: every client hears it, but only the one whose
   // join nonce matches keeps it. The remaining() guard keeps an older/nonce-less client working.
   net::MessageReader reader(message);
@@ -523,7 +523,7 @@ void ServerApp::handleRenameAsset(const net::Message& message) const
 void ServerApp::handleRemoveAsset(const net::Message& message) const
 {
   // An editor deleted an asset: drop the record and re-snapshot. References dangle by design (lookups
-  // null-tolerate a missing uuid) — see ROADMAP B1.
+  // null-tolerate a missing uuid).
   nlohmann::json op;
   try
   {
@@ -759,7 +759,7 @@ void ServerApp::broadcastStateDelta() const
   }
 
   // Binary state delta: packStateDelta writes each object's uuid + local transform straight into the
-  // message, instead of the heavier JSON dump this used to broadcast every tick.
+  // message, rather than a heavier per-tick JSON dump.
   net::Message message(net::MessageType::stateDelta);
   replication::packStateDelta(message, *scene->getObjectManager());
   m_netServer->broadcast(message);

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -54,9 +54,8 @@ ServerApp::ServerApp(LaunchOptions options)
 
   if (m_options.project.empty())
   {
-    // No project file requested: run the built-in sample (scenes 1-3 + falling balls), generated in
-    // code. The procedural scenes can't be a static file, so the whole sample is built here rather than
-    // shipped as a project on disk.
+    // No project file requested: run the built-in sample (scenes 1-3 + falling balls). It's generated in
+    // code because the procedural scenes can't be a static file on disk.
     m_projectSerializer->deserialize(buildDefaultProject());
   }
   else if (!m_projectSerializer->load(m_options.project) || !m_sceneManager->getCurrentScene())
@@ -109,10 +108,8 @@ bool ServerApp::isActive() const
     return true;
   }
 
-  // An editor/client-spawned server is ephemeral: once its spawning app has connected (m_hasConnected,
-  // set on the first join), it should exit as soon as the last connection drops, so it doesn't linger
-  // if the parent ever fails to terminate it. Until that first connection it stays up through the
-  // launch -> connect window (when the count is legitimately still 0).
+  // An ephemeral (editor/client-spawned) server exits once its last connection drops — but only after the
+  // first join (m_hasConnected), so it survives the launch -> connect window when the count is still 0.
   return !m_hasConnected || m_netServer->connectionCount() > 0;
 }
 
@@ -155,9 +152,9 @@ void ServerApp::run()
     {
       fixedUpdate(m_fixedUpdateDt);
 
-      // The tick's scripts have now read this tick's mouse motion + key edges; zero the accumulated
-      // delta/scroll and snapshot the current keys as "last tick's" so a still mouse reads zero next tick
-      // and wasPressed/ReleasedThisTick reflect only genuinely new changes (a catch-up sub-step sees none).
+      // The tick's scripts have read this tick's mouse motion + key edges; zero the accumulated delta/scroll
+      // and snapshot the current keys as "last tick's", so a still mouse reads zero and
+      // wasPressed/ReleasedThisTick reflect only genuinely new changes.
       InputState::clearMouseDeltas();
       InputState::commitInputEdges();
 
@@ -314,10 +311,9 @@ void ServerApp::handleJoin(const net::Message& message, const int32_t senderId)
   m_hasConnected = true;
   const int32_t slot = assignPlayerSlot(senderId);
 
-  // If the joining client tagged its request with a nonce (players do; the editor sends none), tell it
-  // which player slot it was bound to so it can render through that player's camera. Broadcast
-  // + nonce correlation avoids a per-connection send path: every client hears it, but only the one whose
-  // join nonce matches keeps it. The remaining() guard keeps an older/nonce-less client working.
+  // If the client tagged its join with a nonce (players do; the editor sends none), tell it which slot it
+  // got so it can render through that player's camera. Broadcasting with nonce correlation avoids a
+  // per-connection send path — every client hears it, only the matching one keeps it.
   net::MessageReader reader(message);
   if (reader.remaining() >= sizeof(uint64_t))
   {
@@ -543,10 +539,9 @@ void ServerApp::handleRemoveAsset(const net::Message& message) const
 
 void ServerApp::handleInputState(const net::Message& message, const int32_t senderId)
 {
-  // The client's captured keyboard state for this frame; the scripts read it through their player's slot.
-  // It lands in this connection's player slot so two players don't clobber each other. assignPlayerSlot is
-  // idempotent — normally the slot already exists from the join, but bind on demand in case input somehow
-  // arrives first.
+  // The client's captured keyboard state, dropped into its player slot so two players don't clobber each
+  // other. assignPlayerSlot is idempotent (the slot usually exists from the join), but bind on demand in
+  // case input arrives first.
   const int32_t slot = assignPlayerSlot(senderId);
 
   net::MessageReader reader(message);

--- a/source/apps/server/ServerApp.cpp
+++ b/source/apps/server/ServerApp.cpp
@@ -79,7 +79,7 @@ ServerApp::ServerApp(LaunchOptions options)
       logMessage("Error", e.what());
     }
 
-    // The server is headless (no window), so announce that it's up — otherwise a running server looks
+    // The server is headless (no window), so announce that it's up - otherwise a running server looks
     // like it never started.
     logMessage("Info", "Running scene '" + scene->getName() + "' ("
       + std::to_string(scene->getObjectManager()->getAllObjects().size()) + " objects) on port "
@@ -108,7 +108,7 @@ bool ServerApp::isActive() const
     return true;
   }
 
-  // An ephemeral (editor/client-spawned) server exits once its last connection drops — but only after the
+  // An ephemeral (editor/client-spawned) server exits once its last connection drops - but only after the
   // first join (m_hasConnected), so it survives the launch -> connect window when the count is still 0.
   return !m_hasConnected || m_netServer->connectionCount() > 0;
 }
@@ -200,7 +200,7 @@ void ServerApp::fixedUpdate(const float dt) const
     m_collisionSystem->fixedUpdate(objectManager);
 
     // Contact events for this tick: hand CollisionSystem's diffed pair lists to the scripts. Done here
-    // in the app (not as a library call) so sim stays independent of scripting — the collision system
+    // in the app (not as a library call) so sim stays independent of scripting - the collision system
     // produces plain uuid pairs and ScriptSystem consumes them.
     dispatchCollisionEvents(objectManager);
   }
@@ -313,7 +313,7 @@ void ServerApp::handleJoin(const net::Message& message, const int32_t senderId)
 
   // If the client tagged its join with a nonce (players do; the editor sends none), tell it which slot it
   // got so it can render through that player's camera. Broadcasting with nonce correlation avoids a
-  // per-connection send path — every client hears it, only the matching one keeps it.
+  // per-connection send path - every client hears it, only the matching one keeps it.
   net::MessageReader reader(message);
   if (reader.remaining() >= sizeof(uint64_t))
   {

--- a/source/apps/server/ServerApp.h
+++ b/source/apps/server/ServerApp.h
@@ -71,7 +71,7 @@ private:
   // doesn't exit during the launch -> connect window when the count is still 0).
   bool m_hasConnected = false;
 
-  // Player↔connection binding (Phase 3.2): each connection is bound to a player slot (0, 1, ...) on join
+  // Player↔connection binding: each connection is bound to a player slot (0, 1, ...) on join
   // and released on disconnect. inputState from a connection is written into its slot; a script reads its
   // own player's input by resolving its object's PlayerController.playerSlot to that slot. Touched only on
   // the tick thread (join / inputState / disconnect all run there), so no locking is needed.

--- a/source/apps/server/ServerApp.h
+++ b/source/apps/server/ServerApp.h
@@ -71,13 +71,13 @@ private:
   // doesn't exit during the launch -> connect window when the count is still 0).
   bool m_hasConnected = false;
 
-  // Player↔connection binding: each connection is bound to a player slot (0, 1, ...) on join
+  // Player<->connection binding: each connection is bound to a player slot (0, 1, ...) on join
   // and released on disconnect. inputState from a connection is written into its slot; a script reads its
   // own player's input by resolving its object's PlayerController.playerSlot to that slot. Touched only on
   // the tick thread (join / inputState / disconnect all run there), so no locking is needed.
   std::unordered_map<int32_t, int32_t> m_connectionSlots;
 
-  // Bind connId to the lowest free player slot (idempotent — returns the existing slot if already bound).
+  // Bind connId to the lowest free player slot (idempotent - returns the existing slot if already bound).
   int32_t assignPlayerSlot(int32_t connId);
 
   // Release a dropped connection's slot and clear its input.

--- a/source/apps/server/main.cpp
+++ b/source/apps/server/main.cpp
@@ -7,7 +7,7 @@ int main(const int argc, char** argv)
   try
   {
     // --edit is the launch-capability gate that allows editor connections; absent it the server is a
-    // pure play server. (--token is reserved for the auth payload, which isn't enforced yet.)
+    // pure play server. --token, when set, is the secret an editor must present to be authorized.
     // An empty project runs the built-in sample (scenes 1-3 + falling balls); --project loads a file.
     ServerApp::LaunchOptions options;
 

--- a/source/libs/data/ComponentRegistration.cpp
+++ b/source/libs/data/ComponentRegistration.cpp
@@ -30,7 +30,7 @@ void registerDataComponents(ComponentRegistry& componentRegistry)
   // (server only). loadFromJSON sets the className, so the factory is argless like the rest.
   componentRegistry.registerComponent("Script", [] { return std::make_shared<Script>(); });
 
-  // Player↔object association: marks an object as owned by a player slot.
+  // Player<->object association: marks an object as owned by a player slot.
   componentRegistry.registerComponent("PlayerController", [] { return std::make_shared<PlayerController>(); });
 
   // A view the renderer can look through.

--- a/source/libs/data/ComponentRegistration.cpp
+++ b/source/libs/data/ComponentRegistration.cpp
@@ -30,9 +30,9 @@ void registerDataComponents(ComponentRegistry& componentRegistry)
   // (server only). loadFromJSON sets the className, so the factory is argless like the rest.
   componentRegistry.registerComponent("Script", [] { return std::make_shared<Script>(); });
 
-  // Player↔object association (Phase 3.2): marks an object as owned by a player slot.
+  // Player↔object association: marks an object as owned by a player slot.
   componentRegistry.registerComponent("PlayerController", [] { return std::make_shared<PlayerController>(); });
 
-  // A view the renderer can look through (Phase 4).
+  // A view the renderer can look through.
   componentRegistry.registerComponent("Camera", [] { return std::make_shared<Camera>(); });
 }

--- a/source/libs/data/ProjectSerializer.cpp
+++ b/source/libs/data/ProjectSerializer.cpp
@@ -111,7 +111,7 @@ bool ProjectSerializer::load(const std::string& path) const
   std::ifstream f(path);
   if (!f.is_open())
   {
-    // Don't fail silently — the server would otherwise just idle with no scene and no clue why. The
+    // Don't fail silently - the server would otherwise just idle with no scene and no clue why. The
     // path is relative to the working directory, which is the usual culprit (run from the bin dir).
     std::cerr << "[ProjectSerializer] Could not open project file: " << path
               << " (cwd: " << std::filesystem::current_path().string() << ")" << std::endl;

--- a/source/libs/data/Replication.cpp
+++ b/source/libs/data/Replication.cpp
@@ -16,7 +16,7 @@ namespace replication {
 
 void packStateDelta(net::Message& message, const ObjectManager& objectManager)
 {
-  // Collect first so the entry count can lead (Message is append-only — there's no way to back-patch a
+  // Collect first so the entry count can lead (Message is append-only - there's no way to back-patch a
   // header once entries are written). Each entry is uuid + the three local transform vectors.
   struct Entry {
     std::string uuid;

--- a/source/libs/data/Replication.h
+++ b/source/libs/data/Replication.h
@@ -30,14 +30,14 @@ void unpackStateDelta(const ObjectManager& objectManager, const net::Message& me
 // The editor's return path: a single component edit, carried as { object, type, [className], data },
 // where data is the component's own serialize() blob. The server applies it to its authoritative scene
 // (reusing each component's loadFromJSON) and re-broadcasts so every view converges. Reuses the
-// existing serialize()/loadFromJSON boundary — the net layer never names a component type.
+// existing serialize()/loadFromJSON boundary - the net layer never names a component type.
 [[nodiscard]] net::Message buildComponentEdit(const uuids::uuid& objectUUID,
                                               const std::shared_ptr<Component>& component);
 
 void applyComponentEdit(const ObjectManager& objectManager, const net::Message& edit);
 
 // Structural edits (add/remove object or component). Unlike a value edit these change the scene graph,
-// so the server applies them and re-broadcasts a full Snapshot rather than replicating per-op — the
+// so the server applies them and re-broadcasts a full Snapshot rather than replicating per-op - the
 // client/editor just rebuild from the snapshot. Each is carried as { op, ... }.
 [[nodiscard]] nlohmann::json buildAddObject(const std::string& name,
                                             const uuids::uuid* parentUUID = nullptr);
@@ -63,7 +63,7 @@ void applyComponentEdit(const ObjectManager& objectManager, const net::Message& 
 
 // Instantiate a prefab asset into the scene at the transform stored in its body. Unlike every other op
 // this one names an asset rather than an existing object, so applySceneEdit needs the AssetRegistry to
-// resolve the prefab's uuid to its body — pass it whenever prefab ops are possible (the authoritative
+// resolve the prefab's uuid to its body - pass it whenever prefab ops are possible (the authoritative
 // server always does).
 [[nodiscard]] nlohmann::json buildInstantiatePrefab(const uuids::uuid& prefabUUID);
 

--- a/source/libs/data/Replication.h
+++ b/source/libs/data/Replication.h
@@ -99,7 +99,7 @@ void applyAddAsset(AssetRegistry& assetRegistry,
 [[nodiscard]] nlohmann::json unpackAddAsset(const net::Message& message);
 
 // Asset mutation ({ uuid, [displayName] }). Rename is a display-name override only; remove drops the
-// record and lets references dangle (see ROADMAP B1). Both mirror addAsset's local-apply-then-send shape:
+// record and lets references dangle. Both mirror addAsset's local-apply-then-send shape:
 // the editor applies locally for instant feedback and sends the op; the server applies it authoritatively
 // and re-snapshots. The build* helpers assemble the blob; pack*/unpack* carry it on the wire.
 [[nodiscard]] nlohmann::json buildRenameAsset(const uuids::uuid& assetUUID, const std::string& displayName);

--- a/source/libs/data/assets/AssetRegistry.cpp
+++ b/source/libs/data/assets/AssetRegistry.cpp
@@ -119,8 +119,8 @@ nlohmann::json AssetRegistry::getPrefabBody(const uuids::uuid& uuid) const
 
 nlohmann::json AssetRegistry::serialize() const
 {
-  // Scenes are NOT serialized here — they carry their object tree and belong to the SceneManager
-  // migration. The future ProjectSerializer merges this with the scene data.
+  // Scenes are NOT serialized here — they carry their object tree and belong to the SceneManager.
+  // ProjectSerializer merges this with the scene data.
   nlohmann::json data = {
     { "models", nlohmann::json::array() },
     { "textures", nlohmann::json::array() },

--- a/source/libs/data/assets/AssetRegistry.cpp
+++ b/source/libs/data/assets/AssetRegistry.cpp
@@ -41,7 +41,7 @@ void AssetRegistry::renameAsset(const uuids::uuid& uuid, const std::string& disp
   }
 
   // Display-only: `path` (the key, and the name-key for prefabs/scenes) stays put, so nothing that
-  // resolves the asset by path or uuid is disturbed — only the shown name changes.
+  // resolves the asset by path or uuid is disturbed - only the shown name changes.
   it->second.displayName = displayName;
   ++m_version;
 }
@@ -55,7 +55,7 @@ void AssetRegistry::removeAsset(const uuids::uuid& uuid)
   }
 
   // Free the path key too so its name (a prefab/scene display name, or a file path) can be registered
-  // again later. Guard on the mapping actually pointing back at this uuid — a first-wins collision earlier
+  // again later. Guard on the mapping actually pointing back at this uuid - a first-wins collision earlier
   // may have left the key owned by a different record.
   if (const auto pathIt = m_loadedPaths.find(it->second.path);
       pathIt != m_loadedPaths.end() && pathIt->second == uuid)
@@ -119,7 +119,7 @@ nlohmann::json AssetRegistry::getPrefabBody(const uuids::uuid& uuid) const
 
 nlohmann::json AssetRegistry::serialize() const
 {
-  // Scenes are NOT serialized here — they carry their object tree and belong to the SceneManager.
+  // Scenes are NOT serialized here - they carry their object tree and belong to the SceneManager.
   // ProjectSerializer merges this with the scene data.
   nlohmann::json data = {
     { "models", nlohmann::json::array() },
@@ -129,7 +129,7 @@ nlohmann::json AssetRegistry::serialize() const
   };
 
   // A rename sets a display-name override on the record; write it (append only, omitted when empty) so a
-  // renamed asset survives a save/load. The file on disk and `path` never change — only this override.
+  // renamed asset survives a save/load. The file on disk and `path` never change - only this override.
   const auto withDisplayName = [](nlohmann::json entry, const AssetRecord& record) {
     if (!record.displayName.empty())
     {
@@ -221,7 +221,7 @@ void AssetRegistry::loadFromJSON(const nlohmann::json& assetsData)
   {
     for (const auto& assetData : assetsData.at("prefabs"))
     {
-      // A prefab without a usable body is nothing — drop it rather than register a record that can never
+      // A prefab without a usable body is nothing - drop it rather than register a record that can never
       // instantiate (serialize() writes null for a body it couldn't parse).
       if (!assetData.contains("body") || !assetData.at("body").is_object())
       {
@@ -241,8 +241,8 @@ void AssetRegistry::loadFromJSON(const nlohmann::json& assetsData)
 
 void AssetRegistry::pack(net::Message& message) const
 {
-  // Collect first so we can write a count up front (m_assets also holds Scene records, which — like
-  // serialize() — are skipped here; they're carried by the SceneManager). A Prefab carries its whole body
+  // Collect first so we can write a count up front (m_assets also holds Scene records, which - like
+  // serialize() - are skipped here; they're carried by the SceneManager). A Prefab carries its whole body
   // inline; every other record writes an empty body string, keeping the entry layout uniform.
   std::vector<const AssetRecord*> records;
   for (const auto& [uuid, record] : m_assets)

--- a/source/libs/data/assets/AssetRegistry.h
+++ b/source/libs/data/assets/AssetRegistry.h
@@ -29,7 +29,7 @@ struct AssetRecord {
   std::string body;        // prefabs only: a serialized Object blob (Object::serialize().dump())
   std::string displayName; // optional rename override: when non-empty it replaces the derived display
                            // name (see assetDisplay::name). The file on disk and `path` (the registry
-                           // key) never change — a rename is display-only (see ROADMAP B1).
+                           // key) never change — a rename is display-only.
 };
 
 // uuid<->path registry + serialize. Carries asset metadata only (no GPU resources, no GUI).
@@ -48,12 +48,12 @@ public:
 
   // Set a record's display-name override (a display-only rename; the file on disk and `path` — the
   // registry key — are untouched, so name-keyed prefabs/scenes keep their identity). No-op for an unknown
-  // uuid. Bumps the version so cached views refresh. See ROADMAP B1.
+  // uuid. Bumps the version so cached views refresh.
   void renameAsset(const uuids::uuid& uuid, const std::string& displayName);
 
   // Drop a record by uuid, also clearing its `path` key (so a name-keyed prefab name frees up for reuse).
   // No-op for an unknown uuid. References to it dangle by design — lookups already null-tolerate a missing
-  // uuid (see ROADMAP B1). Bumps the version.
+  // uuid. Bumps the version.
   void removeAsset(const uuids::uuid& uuid);
 
   // Drop all records (used when (re)loading a project / applying a fresh snapshot).

--- a/source/libs/data/assets/AssetRegistry.h
+++ b/source/libs/data/assets/AssetRegistry.h
@@ -29,7 +29,7 @@ struct AssetRecord {
   std::string body;        // prefabs only: a serialized Object blob (Object::serialize().dump())
   std::string displayName; // optional rename override: when non-empty it replaces the derived display
                            // name (see assetDisplay::name). The file on disk and `path` (the registry
-                           // key) never change — a rename is display-only.
+                           // key) never change - a rename is display-only.
 };
 
 // uuid<->path registry + serialize. Carries asset metadata only (no GPU resources, no GUI).
@@ -43,16 +43,16 @@ struct AssetRecord {
 class AssetRegistry {
 public:
   // First-wins: re-registering an existing path keeps the original record. The one exception is a Prefab,
-  // whose body is updated in place (keeping its uuid) — see registerAsset.
+  // whose body is updated in place (keeping its uuid) - see registerAsset.
   void registerAsset(const AssetRecord& record);
 
-  // Set a record's display-name override (a display-only rename; the file on disk and `path` — the
-  // registry key — are untouched, so name-keyed prefabs/scenes keep their identity). No-op for an unknown
+  // Set a record's display-name override (a display-only rename; the file on disk and `path` - the
+  // registry key - are untouched, so name-keyed prefabs/scenes keep their identity). No-op for an unknown
   // uuid. Bumps the version so cached views refresh.
   void renameAsset(const uuids::uuid& uuid, const std::string& displayName);
 
   // Drop a record by uuid, also clearing its `path` key (so a name-keyed prefab name frees up for reuse).
-  // No-op for an unknown uuid. References to it dangle by design — lookups already null-tolerate a missing
+  // No-op for an unknown uuid. References to it dangle by design - lookups already null-tolerate a missing
   // uuid. Bumps the version.
   void removeAsset(const uuids::uuid& uuid);
 

--- a/source/libs/data/objects/Object.cpp
+++ b/source/libs/data/objects/Object.cpp
@@ -228,29 +228,24 @@ const std::vector<std::shared_ptr<Component>>& Object::getScripts() const
 
 void Object::pack(net::Message& message) const
 {
-  // UUID
   message.writeString(uuids::to_string(m_uuid));
 
-  // Name
   std::string cleanName = m_name;
   cleanName.erase(std::ranges::find(cleanName, '\0'), cleanName.end());
   message.writeString(cleanName);
 
-  // Components
   message.write(static_cast<uint32_t>(m_components.size()));
   for (const auto& [_, component] : m_components)
   {
     component->pack(message);
   }
 
-  // Scripts
   message.write(static_cast<uint32_t>(m_scripts.size()));
   for (const auto& script : m_scripts)
   {
     script->pack(message);
   }
 
-  // Children
   message.write(static_cast<uint32_t>(m_children.size()));
   for (const auto& child : m_children)
   {
@@ -267,7 +262,6 @@ void Object::unpack(net::MessageReader& messageReader)
 
   const auto& registry = m_manager->getComponentRegistry();
 
-  // Components
   const uint32_t componentCount = messageReader.read<uint32_t>();
   for (uint32_t i = 0; i < componentCount; ++i)
   {
@@ -295,7 +289,6 @@ void Object::unpack(net::MessageReader& messageReader)
     component->unpack(messageReader);
   }
 
-  // Scripts
   const uint32_t scriptCount = messageReader.read<uint32_t>();
   for (uint32_t i = 0; i < scriptCount; ++i)
   {

--- a/source/libs/data/objects/ObjectManager.cpp
+++ b/source/libs/data/objects/ObjectManager.cpp
@@ -32,8 +32,7 @@ void ObjectManager::addObject(const std::shared_ptr<Object>& object)
 {
   object->setManager(this);
 
-  // (Collider registration used to happen here via CollisionManager::addObject; the ECS3DSim
-  // CollisionSystem now discovers colliders by scanning the objects each tick instead.)
+  // Colliders aren't registered here: CollisionSystem discovers them by scanning the objects each tick.
 
   m_allObjects.push_back(object);
 

--- a/source/libs/data/objects/ObjectManager.h
+++ b/source/libs/data/objects/ObjectManager.h
@@ -33,10 +33,10 @@ public:
 
   // Build a live object (and its whole subtree) from a serialized-object blob, giving every node a fresh
   // uuid, and add it at the scene root. This is the prefab instantiation path (a prefab's body is one
-  // Object::serialize() blob — see AssetRegistry::getPrefabBody) and the shared core of duplicateObject.
+  // Object::serialize() blob - see AssetRegistry::getPrefabBody) and the shared core of duplicateObject.
   //
   // Throws if objectData isn't a well-formed serialized object (unknown component type, missing uuid/name);
-  // callers on the tick loop must guard. The returned object is NOT started — a caller spawning into a
+  // callers on the tick loop must guard. The returned object is NOT started - a caller spawning into a
   // running scene starts it (and its children) itself.
   std::shared_ptr<Object> instantiate(const nlohmann::json& objectData);
 

--- a/source/libs/data/objects/components/Camera.h
+++ b/source/libs/data/objects/components/Camera.h
@@ -4,7 +4,7 @@
 #include "Component.h"
 #include <glm/vec3.hpp>
 
-// A view the renderer can look through (Phase 4). Position comes from the object's Transform; the facing
+// A view the renderer can look through. Position comes from the object's Transform; the facing
 // is this component's own `direction`, applied relative to the Transform rotation (so the camera turns as
 // the object turns, but its aim is editable independent of the object's/model's orientation). RenderSystem
 // finds the active camera each frame and pushes its pose/params into the vke renderer; a client picks which

--- a/source/libs/data/objects/components/Camera.h
+++ b/source/libs/data/objects/components/Camera.h
@@ -8,7 +8,7 @@
 // is this component's own `direction`, applied relative to the Transform rotation (so the camera turns as
 // the object turns, but its aim is editable independent of the object's/model's orientation). RenderSystem
 // finds the active camera each frame and pushes its pose/params into the vke renderer; a client picks which
-// camera to render through via the player↔object association (PlayerController).
+// camera to render through via the player<->object association (PlayerController).
 class Camera final : public Component {
 public:
   Camera();

--- a/source/libs/data/objects/components/PlayerController.h
+++ b/source/libs/data/objects/components/PlayerController.h
@@ -4,10 +4,10 @@
 #include "Component.h"
 #include <cstdint>
 
-// Marks an object as owned by a player (Phase 3.2). playerSlot is the player index the object belongs
-// to; the server binds each connection to a slot (see ServerApp), so a script on this object reads that
+// Marks an object as owned by a player. playerSlot is the player index the object belongs to; the
+// server binds each connection to a slot (see ServerApp), so a script on this object reads that
 // player's input via ScriptBase.input. The slot is a ComponentVariable so a script/spawner can rebind it
-// at runtime (a Phase 5 player spawner sets it on a freshly spawned player) and it resets on scene stop.
+// at runtime and it resets on scene stop.
 class PlayerController final : public Component {
 public:
   PlayerController();

--- a/source/libs/data/objects/components/collisions/BoxCollider.h
+++ b/source/libs/data/objects/components/collisions/BoxCollider.h
@@ -49,8 +49,8 @@ public:
   void unpack(net::MessageReader& messageReader) override;
 
 private:
-  // The vke::RenderObject + collider gizmo rendering moved to ECS3DRender; m_renderCollider stays as
-  // a plain flag the editor toggles and the render system reads.
+  // Collider gizmo rendering lives in ECS3DRender; m_renderCollider is a plain flag the editor toggles
+  // and the render system reads.
   bool m_renderCollider = false;
 
   std::array<glm::vec3, boxVertices.size()> m_transformedBoxVertices{};

--- a/source/libs/data/objects/components/collisions/Collider.h
+++ b/source/libs/data/objects/components/collisions/Collider.h
@@ -33,7 +33,7 @@ public:
   [[nodiscard]] ColliderType getColliderType() const;
 
   // A trigger still produces collision events but no physical response (no MTV correction, no
-  // impulses) — a volume scripts can react to without it blocking anything. Shared by every collider
+  // impulses) - a volume scripts can react to without it blocking anything. Shared by every collider
   // shape; each subclass threads it through its own serialize/loadFromJSON/pack/unpack.
   [[nodiscard]] bool isTrigger() const;
   void setIsTrigger(bool isTrigger);

--- a/source/libs/data/scenes/SceneAsset.cpp
+++ b/source/libs/data/scenes/SceneAsset.cpp
@@ -15,7 +15,6 @@ SceneAsset::SceneAsset(const uuids::uuid uuid,
 
 void SceneAsset::loadObjects(const nlohmann::json& objectsData) const
 {
-  // Was AssetManager::loadScenesFromJSON's inner loop.
   for (const auto& objectData : objectsData)
   {
     auto object = std::make_shared<Object>(objectData, m_objectManager.get());

--- a/source/libs/data/scenes/SceneAsset.h
+++ b/source/libs/data/scenes/SceneAsset.h
@@ -14,9 +14,9 @@ namespace net {
 class ObjectManager;
 class ComponentRegistry;
 
-// A scene is data: a named ObjectManager (the object tree). It is no longer part of the polymorphic
-// Asset hierarchy (the file assets are flat records in AssetRegistry); the verbs moved to the systems
-// and displayGui to the editor. start/stop stay (data lifecycle for the play/stop ComponentVariables).
+// A scene is data: a named ObjectManager (the object tree). It is not part of the polymorphic Asset
+// hierarchy (the file assets are flat records in AssetRegistry); behavior lives in the systems and
+// displayGui in the editor. start/stop remain here as data lifecycle for the play/stop ComponentVariables.
 class SceneAsset {
 public:
   SceneAsset(uuids::uuid uuid,

--- a/source/libs/data/scenes/SceneManager.h
+++ b/source/libs/data/scenes/SceneManager.h
@@ -20,7 +20,7 @@ public:
   void addScene(const std::shared_ptr<SceneAsset>& scene);
 
   // Drop all scenes (used when (re)loading a project / applying a fresh snapshot, so stale scenes
-  // don't linger — addScene is keyed by uuid and won't replace an existing entry).
+  // don't linger - addScene is keyed by uuid and won't replace an existing entry).
   void clear();
 
   [[nodiscard]] std::shared_ptr<SceneAsset> getScene(const uuids::uuid& uuid) const;

--- a/source/libs/data/scenes/SceneManager.h
+++ b/source/libs/data/scenes/SceneManager.h
@@ -13,9 +13,8 @@ enum class SceneStatus {
   paused
 };
 
-// Data: the scene store + the play/pause/stop state. The fixedUpdate/variableUpdate verbs are gone —
-// the app loop drives the systems over getCurrentScene()->getObjectManager() when status == running.
-// The Start/Pause/Stop GUI moved to the editor.
+// Data: the scene store + the play/pause/stop state. The app loop drives the systems over
+// getCurrentScene()->getObjectManager() when status == running; the Start/Pause/Stop GUI lives in the editor.
 class SceneManager {
 public:
   void addScene(const std::shared_ptr<SceneAsset>& scene);

--- a/source/libs/editor/AssetBrowserPanel.cpp
+++ b/source/libs/editor/AssetBrowserPanel.cpp
@@ -411,7 +411,7 @@ void AssetBrowserPanel::displayMenuWidget()
   }
 
   // The popup itself is opened/drawn from displayGui at the top level (not here, inside the menu bar),
-  // where ImGui popups behave reliably — displayMenuWidget only records the request.
+  // where ImGui popups behave reliably - displayMenuWidget only records the request.
 }
 
 void AssetBrowserPanel::displayCreateAssetPopup()

--- a/source/libs/editor/AssetInspector.cpp
+++ b/source/libs/editor/AssetInspector.cpp
@@ -125,7 +125,7 @@ void AssetInspector::display(const AssetRecord& record, const std::optional<uuid
   }
 
   // Delete lives at the foot of the panel, for the flat file assets only (a Scene's removal isn't a
-  // registry op — see isRenamable / ROADMAP B1). The modal is drawn every frame the button is armed.
+  // registry op — see isRenamable). The modal is drawn every frame the button is armed.
   displayDeleteButton(record);
   displayDeleteConfirmationModal(record);
 }
@@ -317,8 +317,8 @@ void AssetInspector::displayModelBody(const AssetRecord& record)
   gc::sectionLabel("Preview");
   ImGui::Spacing();
 
-  // A live 3D preview needs an offscreen render target the engine doesn't expose yet (deferred, B3), so
-  // stand in the type icon.
+  // A live 3D preview needs an offscreen render target the engine doesn't expose yet, so stand in the
+  // type icon.
   const float scale = m_assetCache->getRenderer()->getWindow()->getContentScale();
   const float boxW = ImGui::GetContentRegionAvail().x;
   const float boxH = std::min(boxW, 200.0f * scale);

--- a/source/libs/editor/AssetInspector.cpp
+++ b/source/libs/editor/AssetInspector.cpp
@@ -435,9 +435,8 @@ void AssetInspector::displayPrefabBody(const AssetRecord& record)
     return;
   }
 
-  // Draw the body with the same component editors an object uses. The wired callbacks collect structural
-  // edits and mark value edits dirty rather than sending them; apply the structural ones once display has
-  // returned so they don't mutate the component map ObjectInspector::display is iterating.
+  // Draw the body with the same component editors an object uses. Apply the queued structural edits after
+  // display() returns, so they don't mutate the component map ObjectInspector::display is iterating.
   m_pendingPrefabEdits.clear();
 
   m_prefabInspector->display(object);
@@ -453,8 +452,8 @@ void AssetInspector::displayPrefabBody(const AssetRecord& record)
   m_pendingPrefabEdits.clear();
 
   // Coalesce the send: a prefab body update makes the server re-snapshot the whole project, so hold it
-  // until the user isn't actively dragging/typing a widget. The detached object already reflects the edit,
-  // so local feedback stays instant; the network sees one update per interaction instead of per frame.
+  // until the user isn't dragging/typing. The detached object already reflects the edit, so local
+  // feedback stays instant.
   if (m_prefabBodyDirty && !ImGui::IsAnyItemActive())
   {
     flushPrefabBody();
@@ -475,9 +474,8 @@ void AssetInspector::flushPrefabBody()
     return;
   }
 
-  // Re-register under the prefab's name (m_prefabRecordName): re-registering an existing name updates the
-  // body in place and keeps the uuid — the same path "Save as Prefab" over an existing name takes.
-  // markSynced so the resulting registry update (and the server's snapshot echo) doesn't rebuild the object.
+  // Re-register under the prefab's name: this updates the body in place and keeps the uuid. markSynced so
+  // the resulting registry update (and the server's snapshot echo) doesn't rebuild the object.
   const auto newBody = m_prefabBody->serialize();
   m_onUpdatePrefabBody(m_prefabRecordUUID, m_prefabRecordName, newBody);
   m_prefabBody->markSynced(newBody);

--- a/source/libs/editor/AssetInspector.cpp
+++ b/source/libs/editor/AssetInspector.cpp
@@ -31,7 +31,7 @@ AssetInspector::AssetInspector(std::shared_ptr<GpuAssetCache> assetCache,
     m_prefabInspector(std::make_unique<ObjectInspector>(std::move(componentEditor)))
 {
   // The reused inspector edits a detached object, so its edits must apply locally rather than travel to the
-  // server. A value edit already mutated the component in place — just mark the body dirty. A structural
+  // server. A value edit already mutated the component in place - just mark the body dirty. A structural
   // edit is queued and applied after display() returns (applying it now would mutate the component map
   // mid-iteration). Neither sends immediately; displayPrefabBody coalesces the send (see m_prefabBodyDirty).
   m_prefabInspector->setEditCallback([this](const uuids::uuid&, const std::shared_ptr<Component>&) {
@@ -81,7 +81,7 @@ void AssetInspector::setAssetRegistry(const AssetRegistry* registry)
 namespace {
   // A display-name rename is a display-only override the AssetRegistry packs (see AssetRegistry::pack): it
   // survives a snapshot only for the flat file assets. A Scene record is regenerated from the SceneManager
-  // on every snapshot (and never packed), so its override wouldn't stick — keep the scene name read-only.
+  // on every snapshot (and never packed), so its override wouldn't stick - keep the scene name read-only.
   bool isRenamable(const AssetType type)
   {
     return type == AssetType::Model || type == AssetType::Texture
@@ -125,7 +125,7 @@ void AssetInspector::display(const AssetRecord& record, const std::optional<uuid
   }
 
   // Delete lives at the foot of the panel, for the flat file assets only (a Scene's removal isn't a
-  // registry op — see isRenamable). The modal is drawn every frame the button is armed.
+  // registry op - see isRenamable). The modal is drawn every frame the button is armed.
   displayDeleteButton(record);
   displayDeleteConfirmationModal(record);
 }
@@ -133,7 +133,7 @@ void AssetInspector::display(const AssetRecord& record, const std::optional<uuid
 void AssetInspector::displayHeader(const AssetRecord& record)
 {
   // Re-seed the name buffer with the effective display name when the selection changes (only then, so an
-  // external rename can't overwrite an in-progress edit — same discipline as ObjectInspector).
+  // external rename can't overwrite an in-progress edit - same discipline as ObjectInspector).
   if (m_nameEditUUID != record.uuid)
   {
     m_nameEditUUID = record.uuid;
@@ -144,7 +144,7 @@ void AssetInspector::displayHeader(const AssetRecord& record)
   }
 
   // Display name: an editable rename field for the flat file assets (gated on editable), read-only text
-  // for scenes (their override wouldn't survive a snapshot — see isRenamable).
+  // for scenes (their override wouldn't survive a snapshot - see isRenamable).
   if (isRenamable(record.type))
   {
     ImGui::BeginDisabled(!m_editable);
@@ -208,7 +208,7 @@ void AssetInspector::refreshMeta(const AssetRecord& record)
   }
 
   // Mesh stats come from the loaded vke::Model (its vertex/index arrays are already in memory once the
-  // model is cached). Resolving it here — once per selection — reuses the same cache the renderer uses.
+  // model is cached). Resolving it here - once per selection - reuses the same cache the renderer uses.
   if (record.type == AssetType::Model)
   {
     try
@@ -227,7 +227,7 @@ void AssetInspector::refreshMeta(const AssetRecord& record)
   }
 
   // Read the script source from disk (the editor side has the .cs file). Degrades to "not available"
-  // when the file isn't reachable — e.g. attached to a server that shares no filesystem.
+  // when the file isn't reachable - e.g. attached to a server that shares no filesystem.
   if (record.type == AssetType::Script)
   {
     if (std::ifstream in(record.path, std::ios::binary); in)
@@ -430,7 +430,7 @@ void AssetInspector::displayPrefabBody(const AssetRecord& record)
   const auto& object = m_prefabBody->object();
   if (!object)
   {
-    // Empty/malformed body (an older or hand-edited record) — nothing to deserialize.
+    // Empty/malformed body (an older or hand-edited record) - nothing to deserialize.
     gc::dashedBox("Prefab body unavailable");
     return;
   }
@@ -484,7 +484,7 @@ void AssetInspector::flushPrefabBody()
 void AssetInspector::displayDeleteButton(const AssetRecord& record)
 {
   // Only the flat file assets can be deleted from here (a Scene lives in the SceneManager, not a registry
-  // record we can drop — see isRenamable).
+  // record we can drop - see isRenamable).
   if (!isRenamable(record.type))
   {
     return;
@@ -534,7 +534,7 @@ void AssetInspector::displayDeleteConfirmationModal(const AssetRecord& record)
     ImGui::SameLine();
     ImGui::TextUnformatted("?");
 
-    // Deletion always succeeds; any references are left to dangle (the slots show "None") — warn how many.
+    // Deletion always succeeds; any references are left to dangle (the slots show "None") - warn how many.
     if (m_pendingRefCount > 0)
     {
       ImGui::TextColored(theme::scriptAmber, "Referenced by %d object%s - those references will be left empty.",

--- a/source/libs/editor/AssetInspector.h
+++ b/source/libs/editor/AssetInspector.h
@@ -20,7 +20,7 @@ class TransientObject;
 
 // The Inspector's renderer for the Asset selection kind: a common header (type chip, display name, uuid,
 // path/source) shared by every asset type, plus a per-type body. Most views are read-only; the Prefab body
-// is editable (Phase 4) — its contents are deserialized into a detached TransientObject and edited with the
+// is editable — its contents are deserialized into a detached TransientObject and edited with the
 // same component editors an object uses (a reused ObjectInspector), each edit re-serialized and sent as an
 // asset body update. Peer to ObjectInspector behind InspectorPanel's per-selection-kind dispatch.
 class AssetInspector {
@@ -136,7 +136,7 @@ private:
   // Large image preview (falling back to the type icon like the browser tiles) + dimensions + size.
   void displayTextureBody(const AssetRecord& record);
 
-  // Type icon (3D preview deferred, see B3), file format + size, and mesh stats.
+  // Type icon (3D preview deferred), file format + size, and mesh stats.
   void displayModelBody(const AssetRecord& record);
 
   // Read-only .cs source preview (from the cached source, loaded editor-side).
@@ -159,7 +159,7 @@ private:
   void displayDeleteButton(const AssetRecord& record);
 
   // The "Delete Asset?" confirmation modal for m_assetPendingDeletion, warning how many objects reference
-  // it (references are left to dangle — see ROADMAP B1). Confirming fires the remove callback.
+  // it (references are left to dangle). Confirming fires the remove callback.
   void displayDeleteConfirmationModal(const AssetRecord& record);
 };
 

--- a/source/libs/editor/AssetInspector.h
+++ b/source/libs/editor/AssetInspector.h
@@ -20,7 +20,7 @@ class TransientObject;
 
 // The Inspector's renderer for the Asset selection kind: a common header (type chip, display name, uuid,
 // path/source) shared by every asset type, plus a per-type body. Most views are read-only; the Prefab body
-// is editable — its contents are deserialized into a detached TransientObject and edited with the
+// is editable - its contents are deserialized into a detached TransientObject and edited with the
 // same component editors an object uses (a reused ObjectInspector), each edit re-serialized and sent as an
 // asset body update. Peer to ObjectInspector behind InspectorPanel's per-selection-kind dispatch.
 class AssetInspector {
@@ -35,7 +35,7 @@ public:
   // the delete-confirmation modal. Computed by the EditorApp, which owns the scenes and the registry.
   using ReferenceCountCallback = std::function<int(const uuids::uuid& assetUUID)>;
   // A prefab body edit: the EditorApp re-registers the prefab under its existing name (which updates the
-  // body in place, keeping the uuid — the "Save as Prefab" over an existing name path) and re-snapshots.
+  // body in place, keeping the uuid - the "Save as Prefab" over an existing name path) and re-snapshots.
   using UpdatePrefabBodyCallback = std::function<void(const uuids::uuid& assetUUID, const std::string& name,
                                                       const std::string& body)>;
 
@@ -86,7 +86,7 @@ private:
   // verbatim from the Object kind. The inspector's callbacks feed the buffers below rather than the network:
   // structural edits are deferred (applied after its display returns, since applying mid-display would
   // invalidate the component map it iterates); value edits just mark the body dirty. Both apply to the
-  // detached object immediately (instant local feedback), but the SEND is coalesced — see m_prefabBodyDirty.
+  // detached object immediately (instant local feedback), but the SEND is coalesced - see m_prefabBodyDirty.
   std::unique_ptr<TransientObject> m_prefabBody;
   std::unique_ptr<ObjectInspector> m_prefabInspector;
   std::vector<nlohmann::json> m_pendingPrefabEdits;
@@ -95,14 +95,14 @@ private:
   // prefab body update is an addAsset that makes the server re-snapshot the whole project. Sending one per
   // drag frame swamps every view, so edits are coalesced: they mutate the detached object live, set this
   // flag, and are only serialized + sent once the user stops interacting (no active widget) or switches
-  // selection — turning a whole slider drag into a single body update. m_prefabRecord* records which asset
+  // selection - turning a whole slider drag into a single body update. m_prefabRecord* records which asset
   // the pending edit belongs to, so a flush triggered by a selection change sends it under the right key.
   bool m_prefabBodyDirty = false;
   uuids::uuid m_prefabRecordUUID{};
   std::string m_prefabRecordName;
 
   // Buffer for the in-place display-name field. Re-seeded (from the effective display name) whenever the
-  // selected asset changes, so an external rename doesn't clobber what the user is typing — matching
+  // selected asset changes, so an external rename doesn't clobber what the user is typing - matching
   // ObjectInspector's name buffer.
   std::array<char, 256> m_nameEditBuffer{};
   std::optional<uuids::uuid> m_nameEditUUID;

--- a/source/libs/editor/EditorTheme.h
+++ b/source/libs/editor/EditorTheme.h
@@ -3,10 +3,9 @@
 
 #include <imgui.h>
 
-// Design tokens + global style for the ECS3D editor redesign (see "ECS3D Editor.dc" mockup).
+// Design tokens + global style for the ECS3D editor (see "ECS3D Editor.dc" mockup).
 // Both the global ImGuiStyle (setupImGuiStyle) and the custom widgets in GuiComponents.h pull their
-// colors from here so the prototype stays consistent. Fonts and the custom title bar are intentionally
-// out of scope for this prototype.
+// colors from here so they stay consistent. Fonts and the custom title bar are intentionally out of scope.
 namespace theme {
   inline ImVec4 v4(const int r, const int g, const int b, const int a = 255)
   {
@@ -47,7 +46,7 @@ namespace theme {
 
   inline ImU32 u32(const ImVec4& c) { return ImGui::ColorConvertFloat4ToU32(c); }
 
-  // Applies the redesign tokens to the global ImGuiStyle. Call after the ImGui context is current.
+  // Applies the design tokens to the global ImGuiStyle. Call after the ImGui context is current.
   inline void applyStyle()
   {
     ImGuiStyle& s = ImGui::GetStyle();

--- a/source/libs/editor/GuiComponents.h
+++ b/source/libs/editor/GuiComponents.h
@@ -10,12 +10,12 @@
 #include <cstring>
 #include <string>
 
-// Small shared ImGui widgets for the component editors (migrated from core/GuiComponents.h). Lives in
-// ECS3DEditorLib next to the handlers that use it.
+// Small shared ImGui widgets for the component editors, living in ECS3DEditorLib next to the handlers
+// that use it.
 //
-// The widgets below the original xyzGui are redesign-prototype widgets: they render with ImDrawList to
-// match the "ECS3D Editor.dc" mockup (boxed axis fields, accent track sliders, pill badges, filled
-// accent checkboxes). They are drop-in replacements for the stock ImGui calls in the component editors.
+// The widgets below the original xyzGui render with ImDrawList to match the "ECS3D Editor.dc" mockup
+// (boxed axis fields, accent track sliders, pill badges, filled accent checkboxes). They are drop-in
+// replacements for the stock ImGui calls in the component editors.
 namespace gc {
   // A labelled X/Y/Z drag row. Returns true if any of the three was edited this frame.
   inline bool xyzGui(const char* label,
@@ -57,7 +57,7 @@ namespace gc {
   }
 
   // ------------------------------------------------------------------------------------------------
-  // Redesign prototype widgets
+  // Custom-drawn (ImDrawList) widgets
   // ------------------------------------------------------------------------------------------------
 
   // Minimum width of the secondary-text label column on the left of inspector rows.
@@ -216,8 +216,8 @@ namespace gc {
     return edited;
   }
 
-  // Simple vector icon set drawn with ImDrawList (stand-in for the mockup's Lucide icons, since the
-  // icon font is out of scope for this prototype). Drawn centered in a `size`-wide box at `center`.
+  // Simple vector icon set drawn with ImDrawList (stand-in for the mockup's Lucide icons; the icon
+  // font is out of scope). Drawn centered in a `size`-wide box at `center`.
   enum class SecIcon { none, transform, model, rigid, collider, image, rotate, scale, pan,
                        script, scene, folder, plus, minus, light, block, rigidblock, sphere, player,
                        search };

--- a/source/libs/editor/GuiComponents.h
+++ b/source/libs/editor/GuiComponents.h
@@ -63,9 +63,8 @@ namespace gc {
   // Minimum width of the secondary-text label column on the left of inspector rows.
   constexpr float kLabelColumn = 72.0f;
 
-  // Draws a muted row label and advances to the control column. The column is at least kLabelColumn but
-  // always clears the label text (the default ImGui font is wider than the mockup's), so the control is
-  // never drawn on top of the label.
+  // Draws a muted row label and advances to the control column (at least kLabelColumn, but always past
+  // the label text so the control never overlaps it).
   // Gap kept between the end of a row label and the start of its control.
   constexpr float kLabelGap = 22.0f;
 

--- a/source/libs/editor/InspectorPanel.cpp
+++ b/source/libs/editor/InspectorPanel.cpp
@@ -121,7 +121,7 @@ void InspectorPanel::displayGui(const ObjectManager* objectManager, const std::o
   ImGui::Separator();
   ImGui::Spacing();
 
-  // Empty state when nothing renderable is selected — an intentional placeholder rather than a lone
+  // Empty state when nothing renderable is selected - an intentional placeholder rather than a lone
   // checkbox. The copy is kind-agnostic (objects or assets).
   if (!object && !asset)
   {

--- a/source/libs/editor/InspectorPanel.cpp
+++ b/source/libs/editor/InspectorPanel.cpp
@@ -80,8 +80,8 @@ void InspectorPanel::displayGui(const ObjectManager* objectManager, const std::o
 {
   ImGui::Begin("Inspector");
 
-  // Drop a stale asset selection when the registry changed under us and the uuid is gone (deletion in a
-  // later phase, or a fresh snapshot). Gated on the registry version so the membership re-check only
+  // Drop a stale asset selection when the registry changed under us and the uuid is gone (an asset
+  // deletion, or a fresh snapshot). Gated on the registry version so the membership re-check only
   // runs when the registry actually changed, matching the asset browser's cache gating.
   if (const auto assetUUID = m_selection->assetUUID())
   {

--- a/source/libs/editor/InspectorPanel.h
+++ b/source/libs/editor/InspectorPanel.h
@@ -20,11 +20,9 @@ class EditorSelection;
 class ObjectInspector;
 class AssetInspector;
 
-// The editor's inspector panel (the old "Selected Object" window), generalised into a per-kind
-// dispatcher: it owns the window, the empty state, and dispatch on the shared EditorSelection's kind.
-// Today only the Object kind has a renderer (delegated to ObjectInspector); later phases register
-// asset-type renderers behind the same panel. The object edit callbacks + ComponentEditor are handed
-// straight to ObjectInspector, wired exactly as they were on ObjectGUIManager.
+// The editor's inspector panel, a per-kind dispatcher: it owns the window, the empty state, and
+// dispatches on the shared EditorSelection's kind — the Object kind to ObjectInspector, the Asset kind
+// to AssetInspector. The object edit callbacks + ComponentEditor are handed straight to ObjectInspector.
 class InspectorPanel {
 public:
   using EditCallback = std::function<void(const uuids::uuid& objectUUID, const std::shared_ptr<Component>& component)>;

--- a/source/libs/editor/InspectorPanel.h
+++ b/source/libs/editor/InspectorPanel.h
@@ -21,7 +21,7 @@ class ObjectInspector;
 class AssetInspector;
 
 // The editor's inspector panel, a per-kind dispatcher: it owns the window, the empty state, and
-// dispatches on the shared EditorSelection's kind — the Object kind to ObjectInspector, the Asset kind
+// dispatches on the shared EditorSelection's kind - the Object kind to ObjectInspector, the Asset kind
 // to AssetInspector. The object edit callbacks + ComponentEditor are handed straight to ObjectInspector.
 class InspectorPanel {
 public:

--- a/source/libs/editor/ObjectGUIManager.cpp
+++ b/source/libs/editor/ObjectGUIManager.cpp
@@ -386,7 +386,7 @@ void ObjectGUIManager::saveAsPrefab(const std::shared_ptr<Object>& object) const
     return;
   }
 
-  // The prefab body is the object's own serialize() blob, carried inline in the asset record — there is no
+  // The prefab body is the object's own serialize() blob, carried inline in the asset record - there is no
   // file on disk, so it travels with the project and reaches a server that shares no filesystem with us.
   //
   // Prefabs are keyed by display name: saving over an existing name updates that prefab's body in place

--- a/source/libs/editor/ObjectInspector.cpp
+++ b/source/libs/editor/ObjectInspector.cpp
@@ -322,7 +322,7 @@ void ObjectInspector::displayComponent(const uuids::uuid& objectUUID, const std:
   }
 
   // The header's "-" button marks the component deleted; turn that into a structural removeComponent
-  // (sent once — the next snapshot rebuilds the object without it).
+  // (sent once - the next snapshot rebuilds the object without it).
   if (component->markedAsDeleted() && !m_pendingRemovals.contains(component.get()) && m_sceneEditCallback)
   {
     m_pendingRemovals.insert(component.get());

--- a/source/libs/editor/ObjectInspector.h
+++ b/source/libs/editor/ObjectInspector.h
@@ -16,8 +16,8 @@ class ComponentEditor;
 
 // The Inspector's renderer for the Object selection kind: the object's name field, Highlight toggle,
 // component + script widgets (via ComponentEditor), Add Component, and the script drop zone. Extracted
-// from ObjectGUIManager so the panel can dispatch per selection kind; it reports edits back through the
-// same two callbacks the manager used to fire:
+// from ObjectGUIManager so the panel can dispatch per selection kind; it reports edits back through two
+// callbacks:
 //   - a component VALUE change -> EditCallback(objectUUID, component)
 //   - a STRUCTURAL change (rename / add / remove component, add script) -> SceneEditCallback(<edit json>)
 class ObjectInspector {

--- a/source/libs/editor/Selection.h
+++ b/source/libs/editor/Selection.h
@@ -5,7 +5,7 @@
 #include <uuid.h>
 
 // The editor's single selection slot, shared across the panels that read or write it (object tree,
-// viewport picking, and — later phases — the asset browser and the Inspector). A selection is one
+// viewport picking, the asset browser, and the Inspector). A selection is one
 // kind at a time: a scene object, a registry asset, or nothing. Panels branch on kind() to decide
 // what to render/highlight; writers use the select* helpers, so selecting one kind implicitly clears
 // the other (there is a single selection slot, not one per kind).

--- a/source/libs/editor/Selection.h
+++ b/source/libs/editor/Selection.h
@@ -21,7 +21,7 @@ public:
 
   void clear() { m_kind = Kind::None; m_uuid.reset(); }
 
-  // The selected uuid when the selection is of that kind, else nullopt — so callers can branch on the
+  // The selected uuid when the selection is of that kind, else nullopt - so callers can branch on the
   // optional without also checking kind().
   [[nodiscard]] std::optional<uuids::uuid> objectUUID() const
   {

--- a/source/libs/editor/TransientObject.cpp
+++ b/source/libs/editor/TransientObject.cpp
@@ -58,7 +58,7 @@ void TransientObject::rebuild(const std::string& body)
 
   try
   {
-    // A private manager owns the object exactly as a scene's does — but is never handed to any scene,
+    // A private manager owns the object exactly as a scene's does - but is never handed to any scene,
     // SceneManager, or replication path, so the object stays out of the simulation. Preserve the body's
     // uuids (no reassignUUIDs) so the body is stable across edits.
     m_manager = std::make_unique<ObjectManager>(m_componentRegistry);
@@ -77,7 +77,7 @@ void TransientObject::rebuild(const std::string& body)
   }
   catch (const std::exception&)
   {
-    // A malformed body (unknown component type, missing uuid/name) — leave the object null; the inspector
+    // A malformed body (unknown component type, missing uuid/name) - leave the object null; the inspector
     // shows its "unavailable" fallback.
     m_manager.reset();
     m_object.reset();

--- a/source/libs/editor/TransientObject.h
+++ b/source/libs/editor/TransientObject.h
@@ -11,8 +11,8 @@ class ObjectManager;
 
 // A detached Object deserialized from a serialized-object blob (a prefab's AssetRecord::body), living in a
 // private scratch ObjectManager that is never wired to a scene, the SceneManager, or replication. It exists
-// solely so the editor's component editors can operate on prefab contents out-of-scene (see ROADMAP Phase 4
-// / B2). uuids are preserved on load (not reassigned like instantiation), so the body stays stable across
+// solely so the editor's component editors can operate on prefab contents out-of-scene. uuids are
+// preserved on load (not reassigned like instantiation), so the body stays stable across
 // edits; re-serialize after an edit to produce the updated body to send.
 //
 // The private manager is what lets the whole existing deserialize path (Object + children) and

--- a/source/libs/editor/TransientObject.h
+++ b/source/libs/editor/TransientObject.h
@@ -16,7 +16,7 @@ class ObjectManager;
 // edits; re-serialize after an edit to produce the updated body to send.
 //
 // The private manager is what lets the whole existing deserialize path (Object + children) and
-// replication::applySceneEdit be reused verbatim — the "detached" object is detached from any *scene*, not
+// replication::applySceneEdit be reused verbatim - the "detached" object is detached from any *scene*, not
 // from an ObjectManager, which Object fundamentally needs to deserialize and to apply structural edits.
 class TransientObject {
 public:
@@ -24,18 +24,18 @@ public:
 
   ~TransientObject();
 
-  // (Re)build the detached object from `body` when it differs from the blob currently loaded — an external
+  // (Re)build the detached object from `body` when it differs from the blob currently loaded - an external
   // change (a fresh snapshot, or a different prefab selected). Returns true when a rebuild happened (any
   // pointers the caller cached into the old object are now stale). A malformed/empty body clears the object
   // (object() becomes null) and is remembered so it isn't re-parsed every frame. Safe to call every frame.
   bool syncFromBody(const std::string& body);
 
-  // Adopt `body` as the currently-loaded blob WITHOUT rebuilding — call after applying a local edit whose
+  // Adopt `body` as the currently-loaded blob WITHOUT rebuilding - call after applying a local edit whose
   // serialized body you already hold, so the next syncFromBody(recordBody) with that same string is a no-op
   // instead of a rebuild that would discard the live (edited) object.
   void markSynced(const std::string& body);
 
-  // The scratch manager backing the object — replication::applySceneEdit targets this so structural edits
+  // The scratch manager backing the object - replication::applySceneEdit targets this so structural edits
   // (add/remove component, rename, add script) apply to the detached object in place. Null until a
   // successful sync.
   [[nodiscard]] ObjectManager* manager() const;

--- a/source/libs/editor/components/CameraEditor.cpp
+++ b/source/libs/editor/components/CameraEditor.cpp
@@ -29,7 +29,7 @@ void registerCameraEditor(ComponentEditor& componentEditor)
 
       // Only an active camera is picked up by RenderSystem::updateCamera. Note: fov/near/far are carried
       // and serialized, but the engine's projection is currently hardcoded, so editing them has no visible
-      // effect until VulkanEngine exposes a projection setter (see ROADMAP 4.2).
+      // effect until VulkanEngine exposes a projection setter.
       if (gc::accentCheckbox("Active", &active))
       {
         camera->setActive(active);

--- a/source/libs/editor/components/LightRendererEditor.cpp
+++ b/source/libs/editor/components/LightRendererEditor.cpp
@@ -28,8 +28,8 @@ void registerLightRendererEditor(ComponentEditor& componentEditor)
       glm::vec3 direction = light->getDirection();
       float coneAngle = light->getConeAngle();
 
-      // These now write the plain light data directly (the vke::PointLight/SpotLight are built by the
-      // RenderSystem from these values each frame).
+      // These write the plain light data directly; the vke::PointLight/SpotLight are built by the
+      // RenderSystem from these values each frame.
       if (gc::accentCheckbox("Spot Light", &isSpotLight))
       {
         light->setSpotLight(isSpotLight);

--- a/source/libs/net/NetClient.cpp
+++ b/source/libs/net/NetClient.cpp
@@ -87,7 +87,7 @@ void NetClient::send(const Message& message) const
 
 bool NetClient::poll(Message& message)
 {
-  // The client has a single peer (the server), so the sender id is meaningless here — discard it.
+  // The client has a single peer (the server), so the sender id is meaningless here - discard it.
   int32_t senderId = 0;
   return m_inbox.pop(message, senderId);
 }

--- a/source/libs/net/ServerProcess.h
+++ b/source/libs/net/ServerProcess.h
@@ -6,7 +6,7 @@
 namespace net {
 
 // Launches a child ECS3DServer process for singleplayer / local-MP (the editor/client spawn a local
-// server and connect over loopback — the same netcode path as remote). RAII: the child is terminated
+// server and connect over loopback - the same netcode path as remote). RAII: the child is terminated
 // when this object is destroyed, so the local server doesn't outlive its window.
 class ServerProcess {
 public:

--- a/source/libs/net/Transport/Transport.cs
+++ b/source/libs/net/Transport/Transport.cs
@@ -8,12 +8,11 @@ namespace ECS3DNetTransport;
 //
 // This class is just the native boundary: it holds the inbound callbacks C++ registers, exposes the
 // [UnmanagedCallersOnly] exports C++ calls, and forwards every call to the selected TransportBackend.
-// The actual socket work (TCP vs. WebSocket, and later UDP) lives in the backends, which are fully
-// separate code paths. The wire transport is chosen by the hardcoded Protocol field below.
+// The actual socket work (TCP vs. WebSocket) lives in the backends, which are fully separate code
+// paths. The wire transport is chosen by the hardcoded Protocol field below.
 public static unsafe class Transport
 {
   // Hardcoded transport selection. Flip this to switch the wire protocol for the whole process.
-  // UDP will be added later (see TransportProtocol).
 //   private static readonly TransportProtocol Protocol = TransportProtocol.WebSocket;
   private static readonly TransportProtocol Protocol = TransportProtocol.Tcp;
 

--- a/source/libs/net/Transport/Transport.cs
+++ b/source/libs/net/Transport/Transport.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace ECS3DNetTransport;
 
-// The C# socket half of ECS3DNet. The C++ side (NetServer/NetClient) owns the protocol — it only ever
+// The C# socket half of ECS3DNet. The C++ side (NetServer/NetClient) owns the protocol - it only ever
 // hands us an opaque (type byte + payload bytes) pair and gets the same back.
 //
 // This class is just the native boundary: it holds the inbound callbacks C++ registers, exposes the
@@ -22,7 +22,7 @@ public static unsafe class Transport
   private static delegate* unmanaged<byte, byte*, int, void> _clientReceive;
 
   // Fired when a server-side connection drops, carrying its connection id, so the C++ side can release
-  // the player slot bound to it. Optional — the C++ side may never register one.
+  // the player slot bound to it. Optional - the C++ side may never register one.
   private static delegate* unmanaged<int, void> _serverDisconnect;
 
   private static readonly TransportBackend _backend = CreateBackend();

--- a/source/libs/net/Transport/TransportBackend.cs
+++ b/source/libs/net/Transport/TransportBackend.cs
@@ -15,7 +15,7 @@ public enum TransportProtocol
 // selected instance. Inbound messages are pushed up to C++ via Transport.DeliverServer/DeliverClient.
 //
 // Everything below the handshake is transport-specific and lives in the concrete subclasses (TcpBackend,
-// WebSocketBackend). What's shared — and must stay identical across transports — is the connection
+// WebSocketBackend). What's shared - and must stay identical across transports - is the connection
 // handshake/authorization policy, which lives here.
 internal abstract class TransportBackend
 {
@@ -41,7 +41,7 @@ internal abstract class TransportBackend
   public abstract void ClientSend(byte type, nint data, int len);
 
   // Decides whether a connection presenting this handshake payload ([role byte][token UTF-8]) is
-  // allowed onto the server at all. Players connect freely. An editor is admitted too — even against a
+  // allowed onto the server at all. Players connect freely. An editor is admitted too - even against a
   // non-edit server, where it gets a read-only view (the server simply honors no edits from it). The one
   // hard rejection is a real auth failure: an editor offering the wrong token to an edit server that
   // configured one. Whether an admitted editor may actually edit is conveyed separately via editStatus.

--- a/source/libs/net/Transport/WebSocketBackend.cs
+++ b/source/libs/net/Transport/WebSocketBackend.cs
@@ -31,7 +31,7 @@ internal sealed class WebSocketBackend : TransportBackend
   // through SendAsync().GetResult(). A send that fits the socket's send buffer completes synchronously and
   // returns inline; one that doesn't falls back to the async path, whose continuation needs a thread-pool
   // thread. Because our socket threads block on .GetResult(), the pool has to *inject* that thread, which
-  // it throttles to ~one per 15.6ms — a per-message stall that made WebSocket feel laggy versus TCP.
+  // it throttles to ~one per 15.6ms - a per-message stall that made WebSocket feel laggy versus TCP.
   //
   //  - A send buffer larger than a typical message keeps the common case on the synchronous path.
   //  - Raising the thread-pool minimum removes the injection delay for the rare oversized message that
@@ -255,7 +255,7 @@ internal sealed class WebSocketBackend : TransportBackend
       ws.Options.KeepAliveInterval = KeepAlive;
 
       // ClientWebSocket gives no way to set NoDelay on its socket, so it would otherwise leave Nagle's
-      // algorithm enabled — small per-tick messages get held ~40ms (Nagle + delayed ACK), the lag the
+      // algorithm enabled - small per-tick messages get held ~40ms (Nagle + delayed ACK), the lag the
       // TCP backend avoids by setting NoDelay on both ends. A ConnectCallback lets us own the socket and
       // disable Nagle ourselves.
       var invoker = new HttpMessageInvoker(new SocketsHttpHandler

--- a/source/libs/protocol/Protocol.h
+++ b/source/libs/protocol/Protocol.h
@@ -34,7 +34,7 @@ enum class MessageType : uint8_t {
   sceneStatus,   // server -> client: current scene lifecycle state ({ status: "running"|"paused"|"stopped" })
   objectSpawned, // server -> client: one object created at runtime (Object::pack); spliced into the scene
   objectDestroyed, // server -> client: uuid of an object removed at runtime; the client drops it from the scene
-  playerSlot,    // server -> all: (nonce uint64, slot int32) — the player slot bound to the client whose
+  playerSlot,    // server -> all: (nonce uint64, slot int32) - the player slot bound to the client whose
                  // join carried this nonce. Broadcast + nonce correlation (no per-connection send path):
                  // every client hears it, only the one whose join nonce matches keeps it.
   renameAsset,   // editor -> server: set an asset's display-name override (replication::packRenameAsset); server re-snapshots

--- a/source/libs/protocol/Protocol.h
+++ b/source/libs/protocol/Protocol.h
@@ -36,7 +36,7 @@ enum class MessageType : uint8_t {
   objectDestroyed, // server -> client: uuid of an object removed at runtime; the client drops it from the scene
   playerSlot,    // server -> all: (nonce uint64, slot int32) — the player slot bound to the client whose
                  // join carried this nonce. Broadcast + nonce correlation (no per-connection send path):
-                 // every client hears it, only the one whose join nonce matches keeps it (Phase 4.4).
+                 // every client hears it, only the one whose join nonce matches keeps it.
   renameAsset,   // editor -> server: set an asset's display-name override (replication::packRenameAsset); server re-snapshots
   removeAsset    // editor -> server: drop an asset record by uuid (replication::packRemoveAsset); server re-snapshots
   // editComponent/sceneEdit/sceneControl/loadProject/addAsset/renameAsset/removeAsset are the editor's mutation path; the server

--- a/source/libs/render/RenderSystem.cpp
+++ b/source/libs/render/RenderSystem.cpp
@@ -211,7 +211,7 @@ void RenderSystem::updateCamera(const ObjectManager& objectManager, GpuAssetCach
     return;
   }
 
-  // No active component camera in the scene — hand control back to the built-in free-fly camera.
+  // No active component camera in the scene - hand control back to the built-in free-fly camera.
   enableFreeFlyCamera(renderer);
 }
 

--- a/source/libs/render/RenderSystem.h
+++ b/source/libs/render/RenderSystem.h
@@ -21,12 +21,12 @@ public:
   void variableUpdate(const ObjectManager& objectManager, GpuAssetCache& assetCache,
                       const std::optional<uuids::uuid>& highlightUUID = std::nullopt);
 
-  // Drives the vke camera from a component Camera (Phase 4). Finds the active Camera object, builds a
+  // Drives the vke camera from a component Camera. Finds the active Camera object, builds a
   // view matrix from its Transform pose, disables the built-in free-fly camera, and pushes the pose into
   // the renderer. Falls back to (re-enabling) the free-fly camera when no active camera exists. The
   // client calls this each frame; the editor calls it only while its viewport is looking through a scene
   // camera, and calls useFreeFlyCamera() otherwise.
-  // cameraObject optionally restricts the search to one object (Phase 4.4 — a client's own player camera);
+  // cameraObject optionally restricts the search to one object (a client's own player camera);
   // nullopt means "first active camera in the scene".
   void updateCamera(const ObjectManager& objectManager, GpuAssetCache& assetCache,
                     const std::optional<uuids::uuid>& cameraObject = std::nullopt);

--- a/source/libs/scripting/ScriptBridge/ScriptBridge.cs
+++ b/source/libs/scripting/ScriptBridge/ScriptBridge.cs
@@ -22,7 +22,7 @@ public static class Bridge
 
     // Script-to-script access. An object can carry several scripts (one per class), so a script is
     // addressed by type (FindScript<T>) or enumerated for the untyped case (FindScripts). Purely a view
-    // over the live instances — ScriptBase exposes these as getScript<T>/getScripts to user scripts.
+    // over the live instances - ScriptBase exposes these as getScript<T>/getScripts to user scripts.
     internal static T? FindScript<T>(string uuid) where T : ScriptBase =>
         _instances.Values.OfType<T>().FirstOrDefault(s => s.EntityId == uuid);
 

--- a/source/libs/scripting/ScriptBridge/components/Camera.cs
+++ b/source/libs/scripting/ScriptBridge/components/Camera.cs
@@ -11,7 +11,7 @@ public unsafe struct CameraBindings
     public delegate* unmanaged<IntPtr, bool> has;
 }
 
-// The object's camera (Phase 4), scoped to the object it was constructed from. Read-only for now: it
+// The object's camera, scoped to the object it was constructed from. Read-only for now: it
 // exposes the look direction so a script can move relative to where the camera faces. Reads the forward
 // default (0,0,-1) when the object has no Camera.
 public sealed unsafe class Camera

--- a/source/libs/scripting/ScriptBridge/components/World.cs
+++ b/source/libs/scripting/ScriptBridge/components/World.cs
@@ -144,7 +144,7 @@ public static unsafe class World
 
     public static string spawn(string name, Vector3 position) => spawn(name, position.X, position.Y, position.Z);
 
-    // Spawn a prefab asset — its whole object subtree, with fresh uuids — with the root at the given
+    // Spawn a prefab asset - its whole object subtree, with fresh uuids - with the root at the given
     // position, and return the root's uuid. Returns "" when prefabUuid isn't a registered prefab or its
     // body is malformed (the spawn is skipped and the server logs it; nothing throws). The prefab's asset
     // uuid is the one shown by the editor's asset browser.
@@ -194,7 +194,7 @@ public static unsafe class World
         {
             // Native returns "uuid,dist,px,py,pz,nx,ny,nz" into its thread-local buffer, or "" on a miss;
             // marshal it out immediately (return ownership is native's) and parse. ignoreUuid (our arg,
-            // our ownership) lets the caller exclude an object — used to skip self.
+            // our ownership) lets the caller exclude an object - used to skip self.
             raw = Marshal.PtrToStringUTF8(NativeBindings.World.raycast(
                 origin.X, origin.Y, origin.Z, direction.X, direction.Y, direction.Z,
                 maxDistance, layerMask, ignorePtr)) ?? "";

--- a/source/libs/scripting/ScriptSystem.cpp
+++ b/source/libs/scripting/ScriptSystem.cpp
@@ -114,7 +114,7 @@ void ScriptSystem::fixedUpdate(ObjectManager& objectManager, const float dt)
         continue;
       }
 
-      // Lazily (re)create the instance if needed — restores instances after a hot reload.
+      // Lazily (re)create the instance if needed - restores instances after a hot reload.
       if (!isAttached(object->getUUID(), script->getClassName()))
       {
         attach(*object, *script);

--- a/source/libs/scripting/ScriptSystem.h
+++ b/source/libs/scripting/ScriptSystem.h
@@ -17,7 +17,7 @@ class Object;
 class Script;
 
 // Which contact-lifecycle callback a dispatched collision event maps to. The integer values are the
-// wire contract with ScriptBridge.Bridge.onCollision (0 = enter, 1 = stay, 2 = exit) — keep them in sync.
+// wire contract with ScriptBridge.Bridge.onCollision (0 = enter, 1 = stay, 2 = exit) - keep them in sync.
 enum class CollisionEvent {
   enter = 0,
   stay = 1,

--- a/source/libs/scripting/UserScripts/BlockScript.cs
+++ b/source/libs/scripting/UserScripts/BlockScript.cs
@@ -29,7 +29,7 @@ public class BlockScript : ScriptBase
         Console.WriteLine($"[BlockScript] Collision ENTER with {otherUuid}");
     }
 
-    // onCollisionStay fires every tick the contact persists — left unlogged here so it doesn't flood
+    // onCollisionStay fires every tick the contact persists - left unlogged here so it doesn't flood
     // the console. Override it when you need per-tick contact logic.
 
     public override void onCollisionExit(string otherUuid)

--- a/source/libs/scripting/UserScripts/PlayerScript.cs
+++ b/source/libs/scripting/UserScripts/PlayerScript.cs
@@ -52,7 +52,7 @@ public class PlayerScript : ScriptBase
         m_appliedForce *= 0;
 
         // Mouse-look owns rotation, so cancel any physics spin (e.g. from a collision) before physics
-        // integrates it this tick — otherwise the view would fight/jitter against the look direction.
+        // integrates it this tick - otherwise the view would fight/jitter against the look direction.
         rigidBody.setAngularVelocity(0, 0, 0);
     }
 
@@ -141,7 +141,7 @@ public class PlayerScript : ScriptBase
         if (forwardInput != 0 || strafeInput != 0)
         {
             // Base heading is the camera's own facing (its direction field) on the ground plane, so
-            // "forward" follows wherever the camera actually points — not an assumed -Z.
+            // "forward" follows wherever the camera actually points - not an assumed -Z.
             Vector3 camDir = camera.getDirection();
             Vector3 baseForward = new Vector3(camDir.X, 0.0f, camDir.Z);
             baseForward = baseForward.LengthSquared() > 0.0001f

--- a/source/libs/scripting/bindings/BindingContext.h
+++ b/source/libs/scripting/bindings/BindingContext.h
@@ -16,13 +16,13 @@ class ObjectManager;
 //
 // Runtime spawn/destroy from a script can't broadcast directly (the bindings know nothing about the net
 // layer), so the spawn/destroy bindings record what happened here; ServerApp drains these after the tick
-// and replicates them (objectSpawned/objectDestroyed) — keeping scripting independent of net/protocol.
+// and replicates them (objectSpawned/objectDestroyed) - keeping scripting independent of net/protocol.
 //
 // Scene queries (raycast/overlap) live in sim, which scripting can't link, so the server app injects them
 // here as function pointers at startup (see SceneQueries); the World bindings call through them. Signatures
 // use only types both sides share (data + glm + uuid) and must match SceneQueries' statics.
 //
-// The AssetRegistry is injected the same way (once, at startup — the server reassigns its contents on
+// The AssetRegistry is injected the same way (once, at startup - the server reassigns its contents on
 // loadProject but never the object), so the spawnPrefab binding can resolve a prefab uuid to its body.
 class BindingContext {
 public:

--- a/source/libs/scripting/bindings/InputState.h
+++ b/source/libs/scripting/bindings/InputState.h
@@ -61,7 +61,7 @@ public:
   // button is the GLFW mouse-button index (0 = left, 1 = right, 2 = middle).
   [[nodiscard]] static bool isMouseButtonPressed(int32_t playerSlot, int button);
 
-  // Aggregate across every slot — what the player-agnostic global InputUtils reads. A key is "pressed"
+  // Aggregate across every slot - what the player-agnostic global InputUtils reads. A key is "pressed"
   // if any player presses it; "focused" if any player is focused. In the singleplayer case (one slot)
   // the aggregate is just that one player's input.
   [[nodiscard]] static bool isAnyKeyPressed(int key);

--- a/source/libs/scripting/bindings/InputState.h
+++ b/source/libs/scripting/bindings/InputState.h
@@ -10,8 +10,8 @@
 // window) captures the pressed keys each frame and sends them as an inputState message; ServerApp
 // writes them here, and the InputUtils bindings read them.
 //
-// State is kept per player slot (Phase 3.2): the server binds each connection to a player slot and drops
-// that connection's input into its slot, so two players no longer clobber one shared key set. A script
+// State is kept per player slot: the server binds each connection to a player slot and drops that
+// connection's input into its slot, so two players don't clobber one shared key set. A script
 // reads its own player's input by resolving its object's PlayerController.playerSlot to a slot here
 // (ScriptBase.input); the player-agnostic global InputUtils reads the aggregate across all slots.
 //
@@ -63,7 +63,7 @@ public:
 
   // Aggregate across every slot — what the player-agnostic global InputUtils reads. A key is "pressed"
   // if any player presses it; "focused" if any player is focused. In the singleplayer case (one slot)
-  // this is identical to the old single-slot behavior.
+  // the aggregate is just that one player's input.
   [[nodiscard]] static bool isAnyKeyPressed(int key);
 
   [[nodiscard]] static bool isAnyFocused();

--- a/source/libs/scripting/bindings/WorldBindings.cpp
+++ b/source/libs/scripting/bindings/WorldBindings.cpp
@@ -161,7 +161,7 @@ const char* WorldBindingsProvider::bindSpawnObject(const char* name, const float
   objectManager->addObject(object);
 
   // A script only runs while the scene is running, so the newborn must be started too (live component
-  // state) before its transform is positioned — otherwise physics/replication would read stopped values.
+  // state) before its transform is positioned - otherwise physics/replication would read stopped values.
   object->start();
 
   if (const auto transform = object->getComponent<Transform>(ComponentType::transform))
@@ -212,7 +212,7 @@ const char* WorldBindingsProvider::bindSpawnPrefab(const char* prefabUuid, const
   }
 
   // A script only runs while the scene is running, so the whole newborn subtree must be started (live
-  // component state) before the root is positioned — otherwise physics/replication read stopped values.
+  // component state) before the root is positioned - otherwise physics/replication read stopped values.
   startSubtree(*object);
 
   if (const auto transform = object->getComponent<Transform>(ComponentType::transform))
@@ -275,7 +275,7 @@ const char* WorldBindingsProvider::bindRaycast(const float ox, const float oy, c
     return store("");
   }
 
-  // "uuid,dist,px,py,pz,nx,ny,nz" — uuids have no commas, so this parses cleanly on the managed side.
+  // "uuid,dist,px,py,pz,nx,ny,nz" - uuids have no commas, so this parses cleanly on the managed side.
   std::string result = uuids::to_string(hitObject);
   for (const float value : { hitDistance, hitPoint.x, hitPoint.y, hitPoint.z,
                              hitNormal.x, hitNormal.y, hitNormal.z })

--- a/source/libs/scripting/bindings/WorldBindings.h
+++ b/source/libs/scripting/bindings/WorldBindings.h
@@ -45,8 +45,8 @@ private:
   static const char* bindSpawnPrefab(const char* prefabUuid, float x, float y, float z);
 
   // Ray/overlap queries delegate to the sim implementation the app injected into BindingContext. Both
-  // return a comma-delimited string the managed side parses: raycast → "uuid,dist,px,py,pz,nx,ny,nz" (or
-  // "" on a miss); overlapSphere → a comma-separated uuid list (or "").
+  // return a comma-delimited string the managed side parses: raycast -> "uuid,dist,px,py,pz,nx,ny,nz" (or
+  // "" on a miss); overlapSphere -> a comma-separated uuid list (or "").
   static const char* bindRaycast(float ox, float oy, float oz, float dx, float dy, float dz,
                                  float maxDistance, uint32_t layerMask, const char* ignoreUuid);
   static const char* bindOverlapSphere(float cx, float cy, float cz, float radius, uint32_t layerMask,

--- a/source/libs/sim/CollisionSystem.h
+++ b/source/libs/sim/CollisionSystem.h
@@ -79,7 +79,7 @@ private:
   // Broad-phase layer filter: true only if each collider's mask includes the other's layer.
   static bool layersCollide(const std::shared_ptr<Collider>& a, const std::shared_ptr<Collider>& b);
 
-  // GJK/EPA narrow phase, lifted out of Collider.
+  // GJK/EPA narrow phase.
   static bool collidesWith(const std::shared_ptr<Collider>& collider, const std::shared_ptr<Object>& other,
                            glm::vec3* mtv, glm::vec3* collisionPoint);
 

--- a/source/libs/sim/CollisionSystem.h
+++ b/source/libs/sim/CollisionSystem.h
@@ -33,7 +33,7 @@ struct CollisionPair {
 
   // Lexicographic by (a, b). Defaulting the three-way comparison gives the full set of relational
   // operators (uuid has only < and ==, which the compiler synthesizes from), so CollisionPair models
-  // totally_ordered — required by std::ranges::sort / set_difference.
+  // totally_ordered - required by std::ranges::sort / set_difference.
   std::strong_ordering operator<=>(const CollisionPair& other) const = default;
 };
 

--- a/source/libs/sim/collisions/Support.h
+++ b/source/libs/sim/collisions/Support.h
@@ -6,8 +6,8 @@
 
 class Collider;
 
-// Minkowski-difference support point. This was Collider::getSupport; it lives in ECS3DSim now
-// because it is part of the GJK/EPA algorithm, and it only reads the colliders' (data) geometry.
+// Minkowski-difference support point. Lives in ECS3DSim because it is part of the GJK/EPA algorithm,
+// and it only reads the colliders' (data) geometry.
 glm::vec3 getSupport(Collider* collider, const std::shared_ptr<Collider>& other, const glm::vec3& direction);
 
 

--- a/source/libs/sim/queries/SceneQueries.cpp
+++ b/source/libs/sim/queries/SceneQueries.cpp
@@ -23,7 +23,7 @@ namespace {
   }
 
   // The box's world matrix, built the same way BoxCollider::generateTransformedMesh does (note: the box's
-  // own getScale() adds transform+local, but the collision mesh multiplies — so mirror the mesh here so
+  // own getScale() adds transform+local, but the collision mesh multiplies - so mirror the mesh here so
   // ray/overlap match what actually collides). Maps the unit box [-1,1]^3 into world space.
   glm::mat4 boxWorldMatrix(const std::shared_ptr<Transform>& transform, const std::shared_ptr<BoxCollider>& box)
   {
@@ -61,7 +61,7 @@ namespace {
       return false; // sphere entirely behind the origin
     }
 
-    // Origin inside the sphere (near root behind us) → report contact at the origin, so a ray started
+    // Origin inside the sphere (near root behind us) -> report contact at the origin, so a ray started
     // inside a collider (e.g. a body resting on/penetrating it) still detects it.
     const float t = std::max(tNear, 0.0f);
     if (t > maxDistance)
@@ -106,11 +106,11 @@ namespace {
       const float inv = 1.0f / localDir[axis];
       float t1 = (-1.0f - localOrigin[axis]) * inv; // -1 face
       float t2 = (1.0f - localOrigin[axis]) * inv;  // +1 face
-      float entrySign = -1.0f;                      // entering the -1 face → local normal -axis
+      float entrySign = -1.0f;                      // entering the -1 face -> local normal -axis
       if (t1 > t2)
       {
         std::swap(t1, t2);
-        entrySign = 1.0f; // entering the +1 face → local normal +axis
+        entrySign = 1.0f; // entering the +1 face -> local normal +axis
       }
 
       if (t1 > tMin)
@@ -128,7 +128,7 @@ namespace {
     }
 
     // tMax < 0 means the whole box is behind the origin. tMin < 0 <= tMax means the origin is inside the
-    // box → report contact at the origin (t = 0), so a ray started inside a collider still detects it.
+    // box -> report contact at the origin (t = 0), so a ray started inside a collider still detects it.
     if (hitAxis < 0 || tMax < 0.0f)
     {
       return false;

--- a/source/libs/sim/queries/SceneQueries.h
+++ b/source/libs/sim/queries/SceneQueries.h
@@ -9,7 +9,7 @@
 class ObjectManager;
 
 // Analytic scene queries (raycast, sphere overlap) over the collider geometry. Lives in sim because it
-// is query *behavior* over the data (the data/systems split), but scripting can't link sim — so the
+// is query *behavior* over the data (the data/systems split), but scripting can't link sim - so the
 // server app injects these two statics into BindingContext as function pointers at startup. The
 // signatures below therefore use only types both sim and scripting can see (data + glm + uuid) and must
 // stay matched to BindingContext::RaycastFn / OverlapSphereFn.


### PR DESCRIPTION
This pull request makes a comprehensive pass to clarify and modernize comments throughout the codebase, focusing on making them more concise, self-explanatory, and consistent with the project's commenting guidelines. Many comments were rewritten to avoid narrating implementation history, to focus on the current logic, and to reduce redundancy with self-documenting code. No functional code changes were made.

The most important changes are:

**Commenting Standards and Guidelines:**
* [`AGENTS.md`](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R232-R238): Added detailed guidelines for writing concise, purposeful comments, emphasizing self-documenting code and ASCII-only comments.

**Client Application Comments:**
* `source/apps/client/ClientApp.cpp`, `ClientApp.h`: Updated or shortened comments to remove outdated references, clarify intent, and avoid implementation history (e.g., removed "Phase" mentions, focused on current logic). [[1]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaL176-R176) [[2]](diffhunk://#diff-262ff58c392cc5ef3287134512a396b03ef6be147ba5d01ff68d3b6e2a5f9fdaL202-R202) [[3]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aL74-R74) [[4]](diffhunk://#diff-b74b2c5c0dc53d98616ff4de71fe125d84b16e35bf258dee380106dcf32f4d6aL103-R103)

**Editor Application Comments:**
* [`source/apps/editor/EditorApp.cpp`](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L71-R73): Rewrote comments for clarity and brevity across asset management, selection, input handling, GUI updates, and menu logic. Removed historical narration and focused on describing the present behavior. [[1]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L71-R73) [[2]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L144-R160) [[3]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L172-R169) [[4]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L210-R207) [[5]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L233-R236) [[6]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L254-R250) [[7]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L285-R280) [[8]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L322-R315) [[9]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L402-R395) [[10]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L417-R409) [[11]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L436-R439) [[12]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L511-R499) [[13]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L667-R656) [[14]](diffhunk://#diff-1944da5b26407f3d0c70f38867e9995e6d6f591d28fc3f9b324a9393a3a23ce4L704-R693)

These changes improve code maintainability and readability by ensuring comments add unique value and reflect the current state of the code.